### PR TITLE
Null Error Fix when no reason phrase provided by flow

### DIFF
--- a/src/main/mule/template.xml
+++ b/src/main/mule/template.xml
@@ -131,15 +131,12 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                 <otherwise>
                     <http-transform:set-response statusCode="503">
                         <http-transform:body>#[%dw 2.0 
+                                                import update from dw::util::Values
                                                 output application/json 
-                                                --- 
-                                                "circuitBreaker": vars.circuit mapObject ((value, key, index) -> 
-                                                {
-                                                    ((key): value) if(key as String != "timestamp"),
-                                                    (timestamp: now()) if(key as String == "timestamp")
-                                                }
-                                                ) 
-                                                ++ "error": "The circuit is still open, not propagating new requests until " ++ vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod)S" as Period)]</http-transform:body>
+                                                ---
+                                                "circuitBreaker": (vars.circuit update "timestamp" with now())
+                                                ++ "error": "The circuit is still open, not propagating new requests until " 
+                                                ++ vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod)S" as Period)]</http-transform:body>
                     </http-transform:set-response>
                 </otherwise>
             </choice>

--- a/src/main/mule/template.xml
+++ b/src/main/mule/template.xml
@@ -31,7 +31,7 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
             </try>
             <choice>
                 <!--  Condition to allow the application call  -->
-                <when expression="#[((sizeOf(vars.circuit default '') == 0) or ((vars.circuit.timestamp default 0) + (&quot;PT$(vars.circuit.retryPeriod default 0)S&quot; as Period) &lt; now())) or ((vars.circuit.errorCount default 0) &lt; {{{failureThreshold}}}) or vars.circuit.state == &quot;HALF-OPEN&quot; ]">
+                <when expression='#[((sizeOf(vars.circuit default "") == 0) or ((vars.circuit.timestamp default 0) + ("PT$(vars.circuit.retryPeriod default 0)S" as Period) &lt; now())) or ((vars.circuit.errorCount default 0) &lt; {{{failureThreshold}}}) or vars.circuit.state == "HALF-OPEN" ]'>
                     <try>
                         <logger message="http-policy:execute-next" level="DEBUG" category="com.mule.policies.circuitbreaker"/>
                         <http-policy:execute-next />
@@ -58,7 +58,7 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                                       output application/json
                                       var currentErrorCount = (vars.circuit.errorCount default 0) + 1
                                       var state = if(currentErrorCount &lt; {{{failureThreshold}}}) "CLOSED" 
-                                                  else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + (&quot;PT$(vars.circuit.retryPeriod default 0)S&quot; as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN" 
+                                                  else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + ("PT$(vars.circuit.retryPeriod default 0)S" as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN"
                                                   else "OPEN"
                                       ---
                                       {
@@ -93,7 +93,7 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                                               output application/json
                                               var currentErrorCount = (vars.circuit.errorCount default 0) + 1
                                               var state = if(currentErrorCount &lt; {{{failureThreshold}}}) "CLOSED" 
-                                                          else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + (&quot;PT$(vars.circuit.retryPeriod default 0)S&quot; as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN" 
+                                                          else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + ("PT$(vars.circuit.retryPeriod default 0)S" as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN"
                                                           else "OPEN"
                                               ---
                                               {

--- a/src/main/mule/template.xml
+++ b/src/main/mule/template.xml
@@ -74,7 +74,7 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                                         </os:value>
                                     </os:store>
                                     <http-transform:set-response statusCode="503">
-                                        <http-transform:body>#[%dw 2.0 output application/json --- "circuitBreaker": vars.circuit ++ "error": { "code": "$(attributes.statusCode)", "reasonPhrase": "$(attributes.reasonPhrase)"}]</http-transform:body>
+                                        <http-transform:body>#[%dw 2.0 output application/json --- "circuitBreaker": vars.circuit ++ "error": { "code": "$(attributes.statusCode)", ("reasonPhrase": "$(attributes.reasonPhrase)") if (!isEmpty(attributes.reasonPhrase)) }]</http-transform:body>
                                     </http-transform:set-response>
                                 </when>
                                 <otherwise>


### PR DESCRIPTION
Fixes null exception when APIkit flow does not provide attributes.reasonPhrase.  
Also did 2 maintenance/non-functional updates:
- Unescaped double quotes for readability
- Changed mapObject to update() for updating timestamp field on 503 response