### PR TITLE
Retry Period Unit Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ After publishing to Exchange, follow these steps to apply the policy to an exist
 | Parameter | Purpose |
 | ------ | ------ |
 | Failure Threshold | maximum number of errors allowed before tripping the circuit (putting it in OPEN state) |
-| Retry Period | number of seconds the pattern will wait before trying to reach depedent components (underlying APIs) when a new request is received |
+| Retry Period | amount of time the pattern will wait before trying to reach depedent components (underlying APIs) when a new request is received |
+| Retry Period Unit | the time unit for the retry period value: seconds, minutes, or hours |
 | Evaluate the error object to trigger the circuit? | - Checkbox - Select this option if the underlying application propagates the error object. E.g. applications not handling errors or raising custom ones on error handling strategies |
 | Exceptions Array | a comma separated string containing the exception types that are expected to trip the circuit. Example: "MULE:COMPOSITE_ROUTING, HTTP:UNAUTHORIZED, MULE:EXPRESSION" |
 | Evaluate the HTTP response to trigger the circuit? | - Checkbox - Select this option to evaluate the HTTP response (status code). Check this option if evaluate error object option is unchecked.    |
@@ -57,6 +58,7 @@ Connection:keep-alive
     "circuitBreaker": {
         "failureThreshold": 1,
         "retryPeriod": 20,
+        "retryPeriodUnit": "S",
         "state": "OPEN",
         "timestamp": "2019-11-12T14:59:42.942Z",
         "errorCount": 5,
@@ -65,9 +67,10 @@ Connection:keep-alive
 }
 ```
 
-All attributes of the response ​​are self-explanatory, except for errorCount and error. 
-errorCount is a counter that stores the number of requests that has been sent to the API and failed, opening the circuit again. 
-error is an attribute that is populated depending on the scenario: if the underlying API is the one who is tripping the circuit for the inmmediate request, then the error is populated with error.description value propagated by the protected API. Otherwise, the error is returned by the policy itself saying "The circuit is still open, not propagating new requests until ${DATE}". 
+The example above shows a error state of an open circuit, threshold of 1 error, retry period of 20 seconds, and 5 errors encountered.
+
+The `errorCount` field is a counter that stores the number of requests that has been sent to the API and failed, opening the circuit again. 
+The `error` field is an attribute that is populated depending on the scenario: if the underlying API is the one who is tripping the circuit for the inmmediate request, then `error` is populated with `error.description` value propagated by the protected API. Otherwise, the error is returned by the policy itself saying "The circuit is still open, not propagating new requests until ${DATE}".  
 
 Please refer to the following sequence diagram for an example:
 ![](./docs/images/sequence.png)

--- a/circuit-breaker-mule-4.yaml
+++ b/circuit-breaker-mule-4.yaml
@@ -18,11 +18,26 @@ configuration:
     allowMultiple: false
   - propertyName: retryPeriod
     name: Retry Period
-    description: What is the time (in seconds) after which we should retry the failed request once the circuit is in OPEN state?
+    description: What is the amount of time after which we should retry the failed request once the circuit is in OPEN state?
     type: string
     optional: false
     sensitive: false
     allowMultiple: false
+  - propertyName: retryPeriodUnit
+    name: Retry Period Unit
+    description: What is the time unit for the retry period?
+    type: radio
+    options:
+      - name: Seconds
+        value: S
+      - name: Minutes
+        value: M
+      - name: Hours
+        value: H
+    defaultValue: S
+    optional: false
+    sensitive: false
+    allowMultiple: false  
   - propertyName: evaluateErrorObject
     name: Evaluate the error object to trigger the circuit?
     description: Select this option if the underlying application propagates the error object.

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
     <properties>
         <mule.maven.plugin.version>3.2.7</mule.maven.plugin.version>
         <exchange.url>https://maven.anypoint.mulesoft.com/api/v1/organizations/${project.groupId}/maven</exchange.url> <!-- Change this value according your ORG ID -->
-        <os.version>1.1.1</os.version>
-        <http.policy.transform.version>1.0.0</http.policy.transform.version>
+        <os.version>1.2.1</os.version>
+        <http.policy.transform.version>3.1.2</http.policy.transform.version>
     </properties>
 
 

--- a/src/main/mule/template.xml
+++ b/src/main/mule/template.xml
@@ -131,15 +131,12 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                 <otherwise>
                     <http-transform:set-response statusCode="503">
                         <http-transform:body>#[%dw 2.0 
+                                                import update from dw::util::Values
                                                 output application/json 
-                                                --- 
-                                                "circuitBreaker": vars.circuit mapObject ((value, key, index) -> 
-                                                {
-                                                    ((key): value) if(key as String != "timestamp"),
-                                                    (timestamp: now()) if(key as String == "timestamp")
-                                                }
-                                                ) 
-                                                ++ "error": "The circuit is still open, not propagating new requests until " ++ vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod)S" as Period)]</http-transform:body>
+                                                ---
+                                                "circuitBreaker": (vars.circuit update "timestamp" with now())
+                                                ++ "error": "The circuit is still open, not propagating new requests until " 
+                                                ++ vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod)S" as Period)]</http-transform:body>
                     </http-transform:set-response>
                 </otherwise>
             </choice>

--- a/src/main/mule/template.xml
+++ b/src/main/mule/template.xml
@@ -31,7 +31,7 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
             </try>
             <choice>
                 <!--  Condition to allow the application call  -->
-                <when expression="#[((sizeOf(vars.circuit default '') == 0) or ((vars.circuit.timestamp default 0) + (&quot;PT$(vars.circuit.retryPeriod default 0)S&quot; as Period) &lt; now())) or ((vars.circuit.errorCount default 0) &lt; {{{failureThreshold}}}) or vars.circuit.state == &quot;HALF-OPEN&quot; ]">
+                <when expression='#[((sizeOf(vars.circuit default "") == 0) or ((vars.circuit.timestamp default 0) + ("PT$(vars.circuit.retryPeriod default 0)S" as Period) &lt; now())) or ((vars.circuit.errorCount default 0) &lt; {{{failureThreshold}}}) or vars.circuit.state == "HALF-OPEN" ]'>
                     <try>
                         <logger message="http-policy:execute-next" level="DEBUG" category="com.mule.policies.circuitbreaker"/>
                         <http-policy:execute-next />
@@ -58,7 +58,7 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                                       output application/json
                                       var currentErrorCount = (vars.circuit.errorCount default 0) + 1
                                       var state = if(currentErrorCount &lt; {{{failureThreshold}}}) "CLOSED" 
-                                                  else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + (&quot;PT$(vars.circuit.retryPeriod default 0)S&quot; as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN" 
+                                                  else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + ("PT$(vars.circuit.retryPeriod default 0)S" as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN"
                                                   else "OPEN"
                                       ---
                                       {
@@ -93,7 +93,7 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                                               output application/json
                                               var currentErrorCount = (vars.circuit.errorCount default 0) + 1
                                               var state = if(currentErrorCount &lt; {{{failureThreshold}}}) "CLOSED" 
-                                                          else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + (&quot;PT$(vars.circuit.retryPeriod default 0)S&quot; as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN" 
+                                                          else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + ("PT$(vars.circuit.retryPeriod default 0)S" as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN"
                                                           else "OPEN"
                                               ---
                                               {

--- a/src/main/mule/template.xml
+++ b/src/main/mule/template.xml
@@ -74,7 +74,7 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                                         </os:value>
                                     </os:store>
                                     <http-transform:set-response statusCode="503">
-                                        <http-transform:body>#[%dw 2.0 output application/json --- "circuitBreaker": vars.circuit ++ "error": { "code": "$(attributes.statusCode)", "reasonPhrase": "$(attributes.reasonPhrase)"}]</http-transform:body>
+                                        <http-transform:body>#[%dw 2.0 output application/json --- "circuitBreaker": vars.circuit ++ "error": { "code": "$(attributes.statusCode)", ("reasonPhrase": "$(attributes.reasonPhrase)") if (!isEmpty(attributes.reasonPhrase)) }]</http-transform:body>
                                     </http-transform:set-response>
                                 </when>
                                 <otherwise>

--- a/src/main/mule/template.xml
+++ b/src/main/mule/template.xml
@@ -31,7 +31,7 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
             </try>
             <choice>
                 <!--  Condition to allow the application call  -->
-                <when expression='#[((sizeOf(vars.circuit default "") == 0) or ((vars.circuit.timestamp default 0) + ("PT$(vars.circuit.retryPeriod default 0)S" as Period) &lt; now())) or ((vars.circuit.errorCount default 0) &lt; {{{failureThreshold}}}) or vars.circuit.state == "HALF-OPEN" ]'>
+                <when expression='#[((sizeOf(vars.circuit default "") == 0) or ((vars.circuit.timestamp default 0) + ("PT$(vars.circuit.retryPeriod default 0){{{retryPeriodUnit}}}" as Period) &lt; now())) or ((vars.circuit.errorCount default 0) &lt; {{{failureThreshold}}}) or vars.circuit.state == "HALF-OPEN" ]'>
                     <try>
                         <logger message="http-policy:execute-next" level="DEBUG" category="com.mule.policies.circuitbreaker"/>
                         <http-policy:execute-next />
@@ -58,12 +58,13 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                                       output application/json
                                       var currentErrorCount = (vars.circuit.errorCount default 0) + 1
                                       var state = if(currentErrorCount &lt; {{{failureThreshold}}}) "CLOSED" 
-                                                  else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + ("PT$(vars.circuit.retryPeriod default 0)S" as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN"
+                                                  else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + ("PT$(vars.circuit.retryPeriod default 0){{{retryPeriodUnit}}}" as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN"
                                                   else "OPEN"
                                       ---
                                       {
                                         "failureThreshold": {{{failureThreshold}}},
                                         "retryPeriod": {{{retryPeriod}}},
+                                        "retryPeriodUnit": "{{{retryPeriodUnit}}}",
                                         "state": state,
                                         "timestamp": now(),
                                         "errorCount": currentErrorCount
@@ -93,12 +94,13 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                                               output application/json
                                               var currentErrorCount = (vars.circuit.errorCount default 0) + 1
                                               var state = if(currentErrorCount &lt; {{{failureThreshold}}}) "CLOSED" 
-                                                          else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + ("PT$(vars.circuit.retryPeriod default 0)S" as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN"
+                                                          else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + ("PT$(vars.circuit.retryPeriod default 0){{{retryPeriodUnit}}}" as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN"
                                                           else "OPEN"
                                               ---
                                               {
                                                 "failureThreshold": {{{failureThreshold}}},
                                                 "retryPeriod": {{{retryPeriod}}},
+                                                "retryPeriodUnit": "{{{retryPeriodUnit}}}",
                                                 "state": state,
                                                 "timestamp": now(),
                                                 "errorCount": currentErrorCount
@@ -136,7 +138,7 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                                                 ---
                                                 "circuitBreaker": (vars.circuit update "timestamp" with now())
                                                 ++ "error": "The circuit is still open, not propagating new requests until " 
-                                                ++ vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod)S" as Period)]</http-transform:body>
+                                                ++ vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod){{{retryPeriodUnit}}}" as Period)]</http-transform:body>
                     </http-transform:set-response>
                 </otherwise>
             </choice>


### PR DESCRIPTION
Added Retry Period Unit to the policy configuration so the operator can use seconds, minutes, or hours for the retry period, depending on desirability.

Also updated the maven dependencies to the latest versions and tested on Mule 4.4.

This PR is based on the reasonPhrase fix PR and contains those commits.