### PR TITLE
Removed OS:KEY_NOT_FOUND error catch in evaluateErrorObject path.

### DIFF
--- a/src/main/mule/template.xml
+++ b/src/main/mule/template.xml
@@ -121,9 +121,6 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                                         </otherwise>
                                     </choice>
                                 </on-error-propagate>
-                                <on-error-continue type="OS:KEY_NOT_FOUND" logException="false">
-                                    <logger message="Circuit state is CLOSED. Continue processing."  level="DEBUG" category="com.mule.policies.circuitbreaker"/>
-                                </on-error-continue>
                             </error-handler>
                         {{/if}}    
                     </try>


### PR DESCRIPTION
Catch was never reachable, since the catch above it is ANY.  Also, this assumes that error came from the API and not the policy.