### PR TITLE
Made Circuit Breaker Info in response body configurable & added several fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The policy includes several items in the response when triggered.
   - *Circuit Breaker Info*: If the circuit breaker information checkbox is checked, and the circuit breaker is triggered, then the `circuitBreaker` field is added to the response body.  If there is already a response body, it is merged with that; because the body can be any format which may be incompatible with the circuit breaker, the existing body is moved to the `data` field.
 
 **Empty Body**
+
 An empty response body.
 
 ```
@@ -99,6 +100,7 @@ Connection:keep-alive
 ```
 
 **Empty Body + Circuit Breaker Info**
+
 Circuit breaker info is added to an empty response body.
 
 ```
@@ -121,6 +123,7 @@ Connection:keep-alive
 ```
 
 **Exception Check**
+
 Body is description of exception from API.
 
 ```
@@ -134,6 +137,7 @@ Connection:keep-alive
 ```
 
 **Exception Check + Circuit Breaker Info**
+
 Circuit breaker info is added to a response body that contains the error description.
 
 ```
@@ -155,6 +159,7 @@ Connection:keep-alive
 ```
 
 **Status Code Check**
+
 Body is existing response from API.
 
 ```
@@ -168,6 +173,7 @@ Connection:keep-alive
 ```
 
 **Status Code Check + Circuit Breaker Info**
+
 Circuit breaker info is added to a response that already has a body.  API body is moved to `data` field for compatibility.  Status code received from API is added to circuit breaker info.
 
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ After publishing to Exchange, follow these steps to apply the policy to an exist
 | Parameter | Purpose |
 | ------ | ------ |
 | Failure Threshold | maximum number of errors allowed before tripping the circuit (putting it in OPEN state) |
-| Retry Period | number of seconds the pattern will wait before trying to reach depedent components (underlying APIs) when a new request is received |
+| Retry Period | amount of time the pattern will wait before trying to reach depedent components (underlying APIs) when a new request is received |
+| Retry Period Unit | the time unit for the retry period value: seconds, minutes, or hours |
 | Evaluate the error object to trigger the circuit? | - Checkbox - Select this option if the underlying application propagates the error object. E.g. applications not handling errors or raising custom ones on error handling strategies |
 | Exceptions Array | a comma separated string containing the exception types that are expected to trip the circuit. Example: "MULE:COMPOSITE_ROUTING, HTTP:UNAUTHORIZED, MULE:EXPRESSION" |
 | Evaluate the HTTP response to trigger the circuit? | - Checkbox - Select this option to evaluate the HTTP response (status code). Check this option if evaluate error object option is unchecked.    |
@@ -57,6 +58,7 @@ Connection:keep-alive
     "circuitBreaker": {
         "failureThreshold": 1,
         "retryPeriod": 20,
+        "retryPeriodUnit": "S",
         "state": "OPEN",
         "timestamp": "2019-11-12T14:59:42.942Z",
         "errorCount": 5,
@@ -65,9 +67,10 @@ Connection:keep-alive
 }
 ```
 
-All attributes of the response ​​are self-explanatory, except for errorCount and error. 
-errorCount is a counter that stores the number of requests that has been sent to the API and failed, opening the circuit again. 
-error is an attribute that is populated depending on the scenario: if the underlying API is the one who is tripping the circuit for the inmmediate request, then the error is populated with error.description value propagated by the protected API. Otherwise, the error is returned by the policy itself saying "The circuit is still open, not propagating new requests until ${DATE}". 
+The example above shows a error state of an open circuit, threshold of 1 error, retry period of 20 seconds, and 5 errors encountered.
+
+The `errorCount` field is a counter that stores the number of requests that has been sent to the API and failed, opening the circuit again. 
+The `error` field is an attribute that is populated depending on the scenario: if the underlying API is the one who is tripping the circuit for the inmmediate request, then `error` is populated with `error.description` value propagated by the protected API. Otherwise, the error is returned by the policy itself saying "The circuit is still open, not propagating new requests until ${DATE}".  
 
 Please refer to the following sequence diagram for an example:
 ![](./docs/images/sequence.png)

--- a/README.md
+++ b/README.md
@@ -13,23 +13,27 @@ When working on a layered architecture (API-Led is a good example) it doesn't ma
 ### How?
 This policy handles a deterministic model that indicates the state of the circuit. It uses the Mule Object Store (OS) to save and retrieve the values after each call.
 
-When the application starts, OS is initialized using the ${appId} property as key, as shown below:
+When the application starts, OS is initialized using the ${appId} property as key, as shown below.
+
 ![](./docs/images/cbstore.png)
 
 This ensures that every application that uses this policy has isolated circuit state values.
 
-*NOTE* OS settings can be overridden if needed when configuring the policy.
+*NOTE:* OS settings can be overridden if needed when configuring the policy.
 
 ## Circuit Breaker Design
 
 **State Transition**
+
 ![](./docs/images/states-transition.png)
+
 - The policy starts with the circuit in `CLOSED` state, which is the non-error state that allows calls to the API.
 - If the underlying service throws an error, the policy counts it until the maximum number of errors allowed set by the Failure Threshold is reached, then the policy trips the circuit, which is the `OPEN` state.
 - When the policy is in an `OPEN` state, it immediately rejects a new incoming request, unless the timestamp of the last error incremented by the Retry Period exceeds the current timestamp. In that case, the policy transitions to `HALF-OPEN` state and propagates the incoming request.
 - When the policy is in a `HALF-OPEN` state, if the policy receives an error from the last request, it increments the counter and transitions back to `OPEN` state; otherwise, the policy clears the error counter and transitions to `CLOSED` state.
 
 **Sequence Diagram**
+
 ![](./docs/images/sequence.png)
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -1,26 +1,39 @@
 # Circuit-Breaker Custom Policy
 
-This is a custom policy that implements a lightweight Circuit Breaker pattern for Mule 4. By applying this policy to your API, you would be able to:
+This is a custom policy that implements a lightweight Circuit Breaker pattern for Mule 4. By applying this policy to an API, these features are added:
 
-  - Define an error threshold giving your API the flexibility to fail as many times as you define before tripping the circuit
+  - Define an error threshold giving the API the flexibility to fail as many times as you define before tripping the circuit
   - Define a retry period after which the protected API should allow incoming requests
   - Set the circuit to HALF-OPEN state after the threshold is reached and service is still not functional
-  - Perform a dynamic exception handling
+  - Perform dynamic exception handling
 
 ### Why?
-When working on a layered architecture (API Led is a good example) it doesn't make sense to propagate the incoming requests when we know that one of the components of this architecture is not working correctly. This policy provides an entry point for the consumer, preventing spreading calls through the different layers, allowing time to failing resources to recover.
+When working on a layered architecture (API-Led is a good example) it doesn't make sense to propagate the incoming requests when we know that one of the components of this architecture is not working correctly. This policy provides an entry point for the consumer, preventing spreading calls through the different layers, allowing time to failing resources to recover.
 
 ### How?
 This policy handles a deterministic model that indicates the state of the circuit. It uses the Mule Object Store (OS) to save and retrieve the values after each call.
 
-When the application starts, OS is initializated using the ${appId} property as key, as shown below:
+When the application starts, OS is initialized using the ${appId} property as key, as shown below:
 ![](./docs/images/cbstore.png)
 
 This ensures that every application that uses this policy has isolated circuit state values.
 
-*NOTE* OS settings can be overriden if needed when configuring the policy.
+*NOTE* OS settings can be overridden if needed when configuring the policy.
 
-### Usage
+## Circuit Breaker Design
+
+**State Transition**
+![](./docs/images/states-transition.png)
+- The policy starts with the circuit in `CLOSED` state, which is the non-error state that allows calls to the API.
+- If the underlying service throws an error, the policy counts it until the maximum number of errors allowed set by the Failure Threshold is reached, then the policy trips the circuit, which is the `OPEN` state.
+- When the policy is in an `OPEN` state, it immediately rejects a new incoming request, unless the timestamp of the last error incremented by the Retry Period exceeds the current timestamp. In that case, the policy transitions to `HALF-OPEN` state and propagates the incoming request.
+- When the policy is in a `HALF-OPEN` state, if the policy receives an error from the last request, it increments the counter and transitions back to `OPEN` state; otherwise, the policy clears the error counter and transitions to `CLOSED` state.
+
+**Sequence Diagram**
+![](./docs/images/sequence.png)
+
+## Setup
+
 After publishing to Exchange, follow these steps to apply the policy to an existing managed API (or proxy):
 
 * Log into Anypoint Platform
@@ -33,56 +46,166 @@ After publishing to Exchange, follow these steps to apply the policy to an exist
 
 | Parameter | Purpose |
 | ------ | ------ |
-| Failure Threshold | maximum number of errors allowed before tripping the circuit (putting it in OPEN state) |
-| Retry Period | amount of time the pattern will wait before trying to reach depedent components (underlying APIs) when a new request is received |
+| Failure Threshold | maximum number of errors allowed before opening the circuit (putting it in OPEN state) |
+| Retry Period | amount of time to wait before allowing requests into the API after opening a circuit |
 | Retry Period Unit | the time unit for the retry period value: seconds, minutes, or hours |
 | Evaluate the error object to trigger the circuit? | - Checkbox - Select this option if the underlying application propagates the error object. E.g. applications not handling errors or raising custom ones on error handling strategies |
 | Exceptions Array | a comma separated string containing the exception types that are expected to trip the circuit. Example: "MULE:COMPOSITE_ROUTING, HTTP:UNAUTHORIZED, MULE:EXPRESSION" |
 | Evaluate the HTTP response to trigger the circuit? | - Checkbox - Select this option to evaluate the HTTP response (status code). Check this option if evaluate error object option is unchecked.    |
 | HTTP Codes Array | Specify all the HTTP codes that can trip the circuit. The default value is 500 (Internal Server Error). Expect a comma separated string. Example: "500, 401". Double quotes are required but spaces between types are not. |
+| Include the circuit breaker info in the response body? | - Checkbox - Select this option to get circuit information in the response body, which is for troubleshooting. |
 | Override Object Store settings? | - Checkbox - Select this option to override default OS settings. Defaut OS will use persistent OS, with 1 hour entry TTL. |
 | Object Store's entry TTL | The entry timeout. Default value is 1 (hour). |
 | Object Store's entry TTL unit | The time unit. Default value is "HOURS". You can choose one of the listed options based on https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/TimeUnit.html|
 
-Additionally, this policy has the resourceLevelSupported boolean attribute set to true to allow policy support at the resource level.
+This policy can be applied at the resource level or across the entire API.
 
-Once applied, the policy will return the following structure when an error occurs in the application (if it is propagated):
+## Usage
+
+The policy only engages the circuit breaker functionality if `Evaluate the error object to trigger the circuit?` or `Evaluate the HTTP response to trigger the circuit?` is checked, and the corresponding criteria is met.  If neither of those are checked, or the criteria is not met, then the API executes normally without any modification from the policy.
+
+When the circuit is open, the policy returns the `retry-after` header, which is defined in [RFC 2616][retryAfterSpec].  This defines the time, in [HTTP-date format][httpDateSpec], when the circuit breaker will be half-open and allow a call into the API.  This header is not returned if the circuit is closed or half-open.  An example is provided below.
+
+```
+retry-after:Fri, 22 Oct 2021 11:28:21 -05:00
+```
+
+The caller can determine if the circuit breaker is preventing API access by the HTTP response containing the `503` status code and the `retry-after` header.  When the `retry-after` header is in the response, the caller should wait to make another call until after the time in the header.
+
+### Responses
+The policy includes several items in the response when triggered.
+
+- **HTTP Status Code**: When the circuit breaker is triggered (criteria is met or the circuit is open), the policy always returns HTTP status code `503`.
+- **HTTP Header**: When the circuit is open, the policy returns the `retry-after` header.
+- **HTTP Body**: The policy returns different things in the body, depending on the configuration.
+  - *Open Circuit*: When the circuit is open, the policy returns an empty body.
+  - *Exception Check*: When the policy is handling API exceptions and receives an exception in the list, it adds the `error` field to the response body that contains the exception's description. 
+  - *Status Code Check*: When the policy is checking API status codes and receives a code in the list, it returns the API's response body as the response body.  If the API's response body is empty (null, empty string, empty array, empty object), then the policy returns an empty response body.
+  - *Circuit Breaker Info*: If the circuit breaker information checkbox is checked, and the circuit breaker is triggered, then the `circuitBreaker` field is added to the response body.  If there is already a response body, it is merged with that; because the body can be any format which may be incompatible with the circuit breaker, the existing body is moved to the `data` field.
+
+**Empty Body**
+An empty response body.
+
+```
+HTTP/1.0 503 Service Unavailable
+Content-Type:application/json; charset=UTF-8
+retry-after:Fri, 12 Nov 2019 09:60:02 -05:00
+transfer-encoding:chunked
+Connection:keep-alive
+```
+
+**Empty Body + Circuit Breaker Info**
+Circuit breaker info is added to an empty response body.
+
+```
+HTTP/1.0 503 Service Unavailable
+Content-Type:application/json; charset=UTF-8
+retry-after:Fri, 12 Nov 2019 09:60:02 -05:00
+transfer-encoding:chunked
+Connection:keep-alive
+{
+    "circuitBreaker": {
+        "failureThreshold": 3,
+        "retryPeriod": 20,
+        "retryPeriodUnit": "S",
+        "state": "OPEN",
+        "timestamp": "2019-11-12T14:59:42.942Z",
+        "errorCount": 4,
+        "retryAfter": "2019-11-12T14:60:02.942Z"
+    }
+}
+```
+
+**Exception Check**
+Body is description of exception from API.
 
 ```
 HTTP/1.0 503 Service Unavailable
 Content-Type:application/json; charset=UTF-8
 transfer-encoding:chunked
 Connection:keep-alive
-
 {
+	"error": "This is the exception description."
+}
+```
+
+**Exception Check + Circuit Breaker Info**
+Circuit breaker info is added to a response body that contains the error description.
+
+```
+HTTP/1.0 503 Service Unavailable
+Content-Type:application/json; charset=UTF-8
+transfer-encoding:chunked
+Connection:keep-alive
+{
+	"error": "This is the exception description.",
     "circuitBreaker": {
-        "failureThreshold": 1,
+        "failureThreshold": 3,
         "retryPeriod": 20,
         "retryPeriodUnit": "S",
-        "state": "OPEN",
+        "state": "CLOSED",
         "timestamp": "2019-11-12T14:59:42.942Z",
-        "errorCount": 5,
-        "error": "meaningful message"
+        "errorCount": 1
     }
 }
 ```
 
-The example above shows a error state of an open circuit, threshold of 1 error, retry period of 20 seconds, and 5 errors encountered.
+**Status Code Check**
+Body is existing response from API.
 
-The `errorCount` field is a counter that stores the number of requests that has been sent to the API and failed, opening the circuit again. 
-The `error` field is an attribute that is populated depending on the scenario: if the underlying API is the one who is tripping the circuit for the inmmediate request, then `error` is populated with `error.description` value propagated by the protected API. Otherwise, the error is returned by the policy itself saying "The circuit is still open, not propagating new requests until ${DATE}".  
+```
+HTTP/1.0 503 Service Unavailable
+Content-Type:application/json; charset=UTF-8
+transfer-encoding:chunked
+Connection:keep-alive
+{
+	"message": "This is the response body returned by the API."
+}
+```
 
-Please refer to the following sequence diagram for an example:
-![](./docs/images/sequence.png)
+**Status Code Check + Circuit Breaker Info**
+Circuit breaker info is added to a response that already has a body.  API body is moved to `data` field for compatibility.  Status code received from API is added to circuit breaker info.
 
-### States transition
+```
+HTTP/1.0 503 Service Unavailable
+Content-Type:application/json; charset=UTF-8
+transfer-encoding:chunked
+Connection:keep-alive
+{
+	"data": {
+		"message": "This is the response body returned by the API."
+	},
+    "circuitBreaker": {
+        "failureThreshold": 3,
+        "retryPeriod": 20,
+        "retryPeriodUnit": "S",
+        "state": "CLOSED",
+        "timestamp": "2019-11-12T14:59:42.942Z",
+        "errorCount": 1,
+		"errorStatusCode": "500"
+    }
+}
+```
 
-The transition of states can be explained as follows:
-![](./docs/images/states-transition.png)
-- We start with the circuit in CLOSED state
-- If the underlying service throws an error, we count it until we reach the maximum number of errors allowed set by the Failure Threshold, then we trip the circuit (OPEN)
-- If a new incoming request arrives, we reject it immediately, unless the timestamp of the last error plus the Retry Period that we have configured exceeds the current timestamp. In that case, we transition to HALF-OPEN state and we propagate the incoming request
-- If we get an error from that last request, we increment the counter and transition back to OPEN, but, if the request was sucessfull, we clear the error counter and we transition to CLOSED again
+#### Circuit Breaker Info
+
+When circuit breaker info is provided in the response body, it contains the fields below.  Some only show in the conditions described.
+
+- `failureThreshold`: The maximum number of errors allowed before tripping the circuit.
+- `retryPeriod`: The amount of time to wait before allowing requests into the API after opening a circuit.
+- `retryPeriodUnit`: The time unit code for the retry period.
+- `state`: Current state of the circuit.
+- `timestamp`: The date/time of the request.
+- `errorCount`: The number of requests that has been sent to the API and failed.
+- `errorStatusCode`: When checking status codes, this is the status code received from the API which triggered the circuit breaker.  It is in the policy's status code list.
+- `retryAfter`: When the circuit is open, this is date/time when a request will be allowed again.
+
+### Troubleshooting
+
+If the policy is not behaving as expected, developers can follow the troubleshooting options below.
+
+- Enable circuit breaker info in the response body by checking `Include the circuit breaker info in the response body?` checkbox.  This allows the caller to see detailed circuit breaker state in the response body.
+- Enable the policy's loggers.  This allows the operator to see detailed circuit breaker state in the log.  This can be done by adding the following line to log4j2.xml or equivalent depending on infrastructure: `<AsyncLogger name="com.mule.policies.circuitbreaker" level="DEBUG"/>`.
 
 #### Development
 
@@ -109,3 +232,7 @@ Want to contribute? Great!
 
 ### Todos
  - Write Tests
+
+
+[retryAfterSpec]: (https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.37)
+[httpDateSpec]: (https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1)

--- a/README.md
+++ b/README.md
@@ -234,5 +234,5 @@ Want to contribute? Great!
  - Write Tests
 
 
-[retryAfterSpec]: (https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.37)
-[httpDateSpec]: (https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1)
+[retryAfterSpec]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.37
+[httpDateSpec]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Content-Type:application/json; charset=UTF-8
 transfer-encoding:chunked
 Connection:keep-alive
 {
-	"error": "This is the exception description."
+    "error": "This is the exception description."
 }
 ```
 
@@ -138,7 +138,7 @@ Content-Type:application/json; charset=UTF-8
 transfer-encoding:chunked
 Connection:keep-alive
 {
-	"error": "This is the exception description.",
+    "error": "This is the exception description.",
     "circuitBreaker": {
         "failureThreshold": 3,
         "retryPeriod": 20,
@@ -159,7 +159,7 @@ Content-Type:application/json; charset=UTF-8
 transfer-encoding:chunked
 Connection:keep-alive
 {
-	"message": "This is the response body returned by the API."
+    "message": "This is the response body returned by the API."
 }
 ```
 
@@ -172,9 +172,9 @@ Content-Type:application/json; charset=UTF-8
 transfer-encoding:chunked
 Connection:keep-alive
 {
-	"data": {
-		"message": "This is the response body returned by the API."
-	},
+    "data": {
+        "message": "This is the response body returned by the API."
+    },
     "circuitBreaker": {
         "failureThreshold": 3,
         "retryPeriod": 20,
@@ -182,7 +182,7 @@ Connection:keep-alive
         "state": "CLOSED",
         "timestamp": "2019-11-12T14:59:42.942Z",
         "errorCount": 1,
-		"errorStatusCode": "500"
+        "errorStatusCode": "500"
     }
 }
 ```

--- a/circuit-breaker-mule-4.yaml
+++ b/circuit-breaker-mule-4.yaml
@@ -18,11 +18,26 @@ configuration:
     allowMultiple: false
   - propertyName: retryPeriod
     name: Retry Period
-    description: What is the time (in seconds) after which we should retry the failed request once the circuit is in OPEN state?
+    description: What is the amount of time after which we should retry the failed request once the circuit is in OPEN state?
     type: string
     optional: false
     sensitive: false
     allowMultiple: false
+  - propertyName: retryPeriodUnit
+    name: Retry Period Unit
+    description: What is the time unit for the retry period?
+    type: radio
+    options:
+      - name: Seconds
+        value: S
+      - name: Minutes
+        value: M
+      - name: Hours
+        value: H
+    defaultValue: S
+    optional: false
+    sensitive: false
+    allowMultiple: false  
   - propertyName: evaluateErrorObject
     name: Evaluate the error object to trigger the circuit?
     description: Select this option if the underlying application propagates the error object.

--- a/circuit-breaker-mule-4.yaml
+++ b/circuit-breaker-mule-4.yaml
@@ -1,6 +1,6 @@
 id: Circuit Breaker
 name: Circuit Breaker
-description: A custom policy to implement a lightweight Circuit Breaker pattern in Mule 4 APIs
+description: 'This provides a lightweight Circuit Breaker pattern for Mule 4 APIs.  At least one of the "Evaluate Error Object" or "Evaluate HTTP Response" options must be selected to enable circuit breaker functionality.'
 category: Custom
 type: custom
 resourceLevelSupported: true
@@ -11,7 +11,7 @@ providedCharacteristics: []
 configuration:
   - propertyName: failureThreshold
     name: Failure Threshold
-    description: How many failures should happen before trip the circuit (state = OPEN).
+    description: How many failures should happen before tripping the circuit (state = OPEN)?
     type: string
     optional: false
     sensitive: false
@@ -48,9 +48,9 @@ configuration:
     name: Exceptions Array
     description: |
         Specify all the error types that can trip the circuit. The default value is ANY, and means that any exception occurred in the protected application will trigger the circuit.
-        Expect a comma separated string. Example: "MULE:EXPRESSION, HTTP:UNAUTHORIZED". Double quotes are required but spaces between types are not.
+        Separate multiple entries with commas. Example: MULE:EXPRESSION,HTTP:UNAUTHORIZED.
     type: string
-    defaultValue: '"ANY"'
+    defaultValue: ANY
     optional: true
     sensitive: false
     allowMultiple: false
@@ -66,14 +66,20 @@ configuration:
     name: HTTP Codes Array
     description: |
         Specify all the HTTP codes that can trip the circuit. The default value is 500 (Internal Server Error).
-        Expect a comma separated string. Example: "500, 401". Double quotes are required but spaces between types are not.
+        Separate multiple entries with commas. Example: 500,503.
     type: string
-    defaultValue: '"500"'
+    defaultValue: "500"
     optional: true
     sensitive: false
     allowMultiple: false
     dependsOnKey: evaluateHttpResponse
     dependsOnValue: true
+  - propertyName: giveCircuitResponse
+    name: Include the circuit breaker info in the response body?
+    description: Select this option to get circuit breaker info in the response body, which is for troubleshooting.  If not selected, no circuit info is provided in response body, which is the default state.  This does not affect the HTTP status code or the retry-after header, which is sent if the circuit is open.
+    type: boolean
+    optional: true
+    defaultValue: false  
   - propertyName: overrideOsSettings
     name: Override Object Store settings?
     description: Select this option to override default OS settings.
@@ -92,6 +98,8 @@ configuration:
     name: Object Store's entry TTL
     description: The entry timeout. Default value is 1 (hour).
     type: int
+    minimumValue: 1
+    maximumValue: 2000000000
     optional: true
     sensitive: false
     allowMultiple: false
@@ -100,21 +108,21 @@ configuration:
     dependsOnValue: true  
   - propertyName: osTtlUnit
     name: Object Store's entry TTL unit
-    description: The time unit. Default value is "HOURS".
+    description: The time unit. Default value is "Hours".
     options:
-    - name: DAYS
+    - name: Days
       value: "DAYS"  
-    - name: HOURS
+    - name: Hours
       value: "HOURS"
-    - name: MICROSECONDS
+    - name: Microseconds
       value: "MICROSECONDS"
-    - name: MILISECONDS
-      value: "MILISECONDS"  
-    - name: MINUTES
+    - name: Milliseconds
+      value: "MILLISECONDS"  
+    - name: Minutes
       value: "MINUTES"
-    - name: NANOSECONDS
+    - name: Nanoseconds
       value: "NANOSECONDS"
-    - name: SECONDS
+    - name: Seconds
       value: "SECONDS"
     type: radio
     defaultValue: HOURS

--- a/mule-artifact.json
+++ b/mule-artifact.json
@@ -1,3 +1,3 @@
 {
-  "minMuleVersion": "4.1.1"
+  "minMuleVersion": "4.3.0"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>9033ff23-884a-4352-b75b-14fc8237b2c4</groupId> <!-- Change this value according your ORG ID -->
+	<groupId>ORG-ID</groupId> <!-- Change this value according your ORG ID -->
 	<artifactId>circuit-breaker-mule-4</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
     <properties>
         <mule.maven.plugin.version>3.2.7</mule.maven.plugin.version>
         <exchange.url>https://maven.anypoint.mulesoft.com/api/v1/organizations/${project.groupId}/maven</exchange.url> <!-- Change this value according your ORG ID -->
-        <os.version>1.1.1</os.version>
-        <http.policy.transform.version>1.0.0</http.policy.transform.version>
+        <os.version>1.2.1</os.version>
+        <http.policy.transform.version>3.1.2</http.policy.transform.version>
     </properties>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,90 +1,96 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-    <groupId>9033ff23-884a-4352-b75b-14fc8237b2c4</groupId> <!-- Change this value according your ORG ID -->
-    <artifactId>circuit-breaker-mule-4</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+	<groupId>9033ff23-884a-4352-b75b-14fc8237b2c4</groupId> <!-- Change this value according your ORG ID -->
+	<artifactId>circuit-breaker-mule-4</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
 
-    <name>circuit-breaker-mule-4</name>
-    <description>A custom policy to implement a lightweight Circuit Breaker pattern</description>
+	<name>circuit-breaker-mule-4</name>
+	<description>A custom policy to implement a lightweight Circuit Breaker pattern</description>
 
-    <packaging>mule-policy</packaging>
+	<packaging>mule-policy</packaging>
 
-    <properties>
-        <mule.maven.plugin.version>3.2.7</mule.maven.plugin.version>
-        <exchange.url>https://maven.anypoint.mulesoft.com/api/v1/organizations/${project.groupId}/maven</exchange.url> <!-- Change this value according your ORG ID -->
-        <os.version>1.2.1</os.version>
-        <http.policy.transform.version>3.1.2</http.policy.transform.version>
-    </properties>
+	<properties>
+		<mule.maven.plugin.version>3.5.3</mule.maven.plugin.version>
+		<exchange.url>https://maven.anypoint.mulesoft.com/api/v1/organizations/${project.groupId}/maven</exchange.url>
+		<os.version>1.2.1</os.version>
+		<http.policy.transform.version>3.1.2</http.policy.transform.version>
+	</properties>
 
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.mule.tools.maven</groupId>
-                <artifactId>mule-maven-plugin</artifactId>
-                <version>${mule.maven.plugin.version}</version>
-                <extensions>true</extensions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>upload-template</id>
-                        <phase>deploy</phase>
-                        <goals>
-                            <goal>deploy-file</goal>
-                        </goals>
-                        <configuration>
-                            <repositoryId>exchange-server</repositoryId>
-                            <url>${exchange.url}</url>
-                            <file>${project.basedir}/${project.artifactId}.yaml</file>
-                            <generatePom>false</generatePom>
-                            <groupId>${project.groupId}</groupId>
-                            <artifactId>${project.artifactId}</artifactId>
-                            <version>${project.version}</version>
-                            <packaging>yaml</packaging>
-                            <classifier>policy-definition</classifier>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.mule.tools.maven</groupId>
+				<artifactId>mule-maven-plugin</artifactId>
+				<version>${mule.maven.plugin.version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>upload-template</id>
+						<phase>deploy</phase>
+						<goals>
+							<goal>deploy-file</goal>
+						</goals>
+						<configuration>
+							<repositoryId>exchange-server</repositoryId>
+							<url>${exchange.url}</url>
+							<file>${project.basedir}/${project.artifactId}.yaml</file>
+							<generatePom>false</generatePom>
+							<groupId>${project.groupId}</groupId>
+							<artifactId>${project.artifactId}</artifactId>
+							<version>${project.version}</version>
+							<packaging>yaml</packaging>
+							<classifier>policy-definition</classifier>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.mule.connectors</groupId>
-            <artifactId>mule-objectstore-connector</artifactId>
-            <version>${os.version}</version>
-            <classifier>mule-plugin</classifier>
-        </dependency>
-        <dependency>
-           <groupId>com.mulesoft.anypoint</groupId>
-           <artifactId>mule-http-policy-transform-extension</artifactId>
-           <version>${http.policy.transform.version}</version>
-           <classifier>mule-plugin</classifier>
-       </dependency>
-    </dependencies>
+	<dependencies>
+		<dependency>
+			<groupId>org.mule.connectors</groupId>
+			<artifactId>mule-objectstore-connector</artifactId>
+			<version>${os.version}</version>
+			<classifier>mule-plugin</classifier>
+		</dependency>
+		<dependency>
+			<groupId>com.mulesoft.anypoint</groupId>
+			<artifactId>mule-http-policy-transform-extension</artifactId>
+			<version>${http.policy.transform.version}</version>
+			<classifier>mule-plugin</classifier>
+			<exclusions>
+				<exclusion>
+					<groupId>org.mule.connectors</groupId>
+					<artifactId>mule-http-connector</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+	</dependencies>
 
-    <distributionManagement>
-        <repository>
-            <id>exchange-server</id>
-            <name>Corporate Repository</name>
-            <url>${exchange.url}</url>
-            <layout>default</layout>
-        </repository>
-    </distributionManagement>
+	<distributionManagement>
+		<repository>
+			<id>exchange-server</id>
+			<name>Corporate Repository</name>
+			<url>${exchange.url}</url>
+			<layout>default</layout>
+		</repository>
+	</distributionManagement>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>mule-plugin</id>
-            <name>Mule Repository</name>
-            <url>https://repository.mulesoft.org/nexus/content/repositories/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>mule-plugin</id>
+			<name>Mule Repository</name>
+			<url>https://repository.mulesoft.org/nexus/content/repositories/public/</url>
+		</pluginRepository>
+	</pluginRepositories>
 </project>

--- a/src/main/mule/template.xml
+++ b/src/main/mule/template.xml
@@ -131,15 +131,12 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                 <otherwise>
                     <http-transform:set-response statusCode="503">
                         <http-transform:body>#[%dw 2.0 
+                                                import update from dw::util::Values
                                                 output application/json 
-                                                --- 
-                                                "circuitBreaker": vars.circuit mapObject ((value, key, index) -> 
-                                                {
-                                                    ((key): value) if(key as String != "timestamp"),
-                                                    (timestamp: now()) if(key as String == "timestamp")
-                                                }
-                                                ) 
-                                                ++ "error": "The circuit is still open, not propagating new requests until " ++ vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod)S" as Period)]</http-transform:body>
+                                                ---
+                                                "circuitBreaker": (vars.circuit update "timestamp" with now())
+                                                ++ "error": "The circuit is still open, not propagating new requests until " 
+                                                ++ vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod)S" as Period)]</http-transform:body>
                     </http-transform:set-response>
                 </otherwise>
             </choice>

--- a/src/main/mule/template.xml
+++ b/src/main/mule/template.xml
@@ -18,17 +18,17 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
     {{else}}
         <os:object-store name="cbstore" persistent="true" entryTtl="1" entryTtlUnit="HOURS" />
     {{/if}}
-	
-	<!-- Main Policy -->
+    
+    <!-- Main Policy -->
     <http-policy:proxy name="{{{policyId}}}-custom-policy">
         <http-policy:source>
             <flow-ref name="getStatusFromCache" />
             <choice>                
                 <when expression='#[ ((sizeOf(vars.circuit default "") == 0) or ((vars.circuit.timestamp default 0) + ("PT$(vars.circuit.retryPeriod default 0){{{retryPeriodUnit}}}" as Period) &lt; now())) or ((vars.circuit.errorCount default 0) &lt; {{{failureThreshold}}}) or vars.circuit.state == "HALF-OPEN" ]'>
-					<!-- Circuit is closed or half-open -->
-				{{#if evaluateErrorObject}}
+                    <!-- Circuit is closed or half-open -->
+                {{#if evaluateErrorObject}}
                     <try>
-				{{/if}}
+                {{/if}}
                         <logger message="http-policy:execute-next" level="DEBUG" category="com.mule.policies.circuitbreaker"/>
                         <http-policy:execute-next />
                         <logger message="#[attributes]" level="DEBUG" category="com.mule.policies.circuitbreaker"/>
@@ -41,212 +41,212 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                                 <os:remove key="${apiId}" objectStore="cbstore"  />
                             </otherwise>
                         </choice>
-				{{#if evaluateHttpResponse}}
+                {{#if evaluateHttpResponse}}
                             <flow-ref name="evaluateHttpResponse" />
-				{{/if}}
-				{{#if evaluateErrorObject}}
+                {{/if}}
+                {{#if evaluateErrorObject}}
                             <error-handler>
                                 <on-error-propagate type="ANY" logException="true">
                                     <flow-ref name="evaluateErrorObject" />
                                 </on-error-propagate>
                             </error-handler>  
                     </try>
-				{{/if}}
+                {{/if}}
                 </when>
                 <otherwise>
-					<!-- Circuit open -->
+                    <!-- Circuit open -->
                     <flow-ref name="processOpenCircuit" />
                 </otherwise>
             </choice>
         </http-policy:source>
     </http-policy:proxy>
 
-	<!-- SUBFLOWS: can be used in Studio UI -->
-	
-	<!-- Get circuit's previous state from cache -->
-	<sub-flow name="getStatusFromCache">
-		<try>
-			<!-- Checking Cache for OPEN| HALF-OPEN stored value -->
-			<os:retrieve key="${apiId}" target="circuit"  objectStore="cbstore" doc:name="Get status from OS"/>
-			<error-handler>
-				<on-error-continue type="OS:KEY_NOT_FOUND" logException="false" >
-					<logger message="Circuit is CLOSED. Continue processing. Before execution" level="DEBUG" category="com.mule.policies.circuitbreaker" doc:name="Logger"/>
-				</on-error-continue>
-			</error-handler>
-		</try>
-	</sub-flow>
-	
+    <!-- SUBFLOWS: can be used in Studio UI -->
+    
+    <!-- Get circuit's previous state from cache -->
+    <sub-flow name="getStatusFromCache">
+        <try>
+            <!-- Checking Cache for OPEN| HALF-OPEN stored value -->
+            <os:retrieve key="${apiId}" target="circuit"  objectStore="cbstore" doc:name="Get status from OS"/>
+            <error-handler>
+                <on-error-continue type="OS:KEY_NOT_FOUND" logException="false" >
+                    <logger message="Circuit is CLOSED. Continue processing. Before execution" level="DEBUG" category="com.mule.policies.circuitbreaker" doc:name="Logger"/>
+                </on-error-continue>
+            </error-handler>
+        </try>
+    </sub-flow>
+    
     <sub-flow name="errorLogger">
-		<logger level="ERROR" message="#[%dw 2.0 output application/json --- errorMessage:  (error.errorType.namespace ++ ':' ++ error.errorType.identifier)]" category="com.mule.policies.circuitbreaker" doc:name="Log error"/>
-	</sub-flow>
+        <logger level="ERROR" message="#[%dw 2.0 output application/json --- errorMessage:  (error.errorType.namespace ++ ':' ++ error.errorType.identifier)]" category="com.mule.policies.circuitbreaker" doc:name="Log error"/>
+    </sub-flow>
 
-	<!-- Update circuit state and cache it -->
-	<sub-flow name="updateCircuit">
-		<set-variable variableName="circuit" 
-			value='#[%dw 2.0
-				output application/json
-				var currentErrorCount = (vars.circuit.errorCount default 0) + 1
-				var state = if(currentErrorCount &lt; {{{failureThreshold}}}) "CLOSED" 
-						  else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + ("PT$(vars.circuit.retryPeriod default 0){{{retryPeriodUnit}}}" as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN"
-						  else "OPEN"
-				---
-				{
-					"failureThreshold": {{{failureThreshold}}},
-					"retryPeriod": {{{retryPeriod}}},
-					"retryPeriodUnit": "{{{retryPeriodUnit}}}",
-					"state": state,
-					"timestamp": now(),
-					"errorCount": currentErrorCount
-				}]' doc:name="Set Circuit Breaker Info"/>
-		<logger level="DEBUG" doc:name="Updated Circuit Info" doc:id="48d22930-92e1-42eb-b446-bb846bf08c91" message='#[vars.circuit default {}]' category="com.mule.policies.circuitbreaker" />
-		<os:store key="${apiId}" objectStore="cbstore" doc:name="Save status to OS">
-			<os:value>
-				#[vars.circuit]
-			</os:value>
-		</os:store>
-	</sub-flow>
-	
-	<!-- Evaluate circuit state based on API response's status code.  If CB info is disabled, then body is API response body.  
-		If CB info is enabled, then body is CB field and data field with API response body. -->
-	<sub-flow name="evaluateHttpResponse">
-		<choice doc:name="Is status code in CB list?">
-			<when expression='#[output application/json 
-								var httpCodesArray=(("{{{httpCodesArray}}}" replace " " with "") splitBy  ",") as Array 
-								--- 
-								(httpCodesArray contains (attributes.statusCode as String))]'>
-				<logger message="HTTP Status Code is included in the HTTP Codes Array" level="DEBUG" category="com.mule.policies.circuitbreaker" doc:name="HTTP Status Code in list"/>
-				<flow-ref name="updateCircuit" doc:name="updateCircuit"/>
-				<set-variable variableName="response" doc:name="Set Response Info"
-					value='#[output application/json
-					{{#if giveCircuitResponse}}
-						import update from dw::util::Values
-						var isOpen = vars.circuit.state == "OPEN" default false
-						var retryAfter = vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod){{{retryPeriodUnit}}}" as Period) as String
-					{{/if}}
-						---
-						{	
-							status: 503,
-					{{#if giveCircuitResponse}}
-							body: {
-								(data: payload) if (!isEmpty(payload)),
-								circuitBreaker: vars.circuit update {
-									case .errorStatusCode! -> attributes.statusCode as String
-									case .retryAfter! if (isOpen) -> retryAfter
-								}
-							}
-					{{else}}
-							body: payload
-					{{/if}}								
-						}]' />
-				<flow-ref name="setResponse" doc:name="setResponse"/>
-			</when>
-			<otherwise>
-				<logger message="HTTP Status Code not included in the HTTP Codes Array" level="DEBUG" category="com.mule.policies.circuitbreaker" doc:name="HTTP Status Code not in list"/>
-			</otherwise>
-		</choice>
-	</sub-flow>
-	
-	<!-- Evaluate circuit state based on error thrown from API.  This always returns error field in body and will add CB info if enabled. -->
-	<sub-flow name="evaluateErrorObject">
-		<flow-ref name="errorLogger" doc:name="errorLogger"/>
-		<choice doc:name="Is exception in CB list?">
-			<when expression='#[output application/json var exceptionsArray=(("{{{exceptionsArray}}}" replace " " with "") splitBy  ",") as Array --- (exceptionsArray contains (error.errorType.namespace ++ ":" ++ error.errorType.identifier) ) or ( (sizeOf(exceptionsArray) == 1) and (exceptionsArray contains "ANY"))]'>
-				
-				<logger level="DEBUG" doc:name="Exception in list" doc:id="d5857c44-0728-4ca9-a78e-6bb2491d6c02" message="Exception is included in the Exceptions Array" category="com.mule.policies.circuitbreaker" />
-				<flow-ref name="updateCircuit" doc:name="updateCircuit"/>
-				<set-variable variableName="response" doc:name="Set Response Info"
-					value='#[output application/json
-					{{#if giveCircuitResponse}}
-						import update from dw::util::Values
-						var isOpen = vars.circuit.state == "OPEN" default false
-						var retryAfter = vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod){{{retryPeriodUnit}}}" as Period) as String
-					{{/if}}
-						---
-						{			
-							status: 503,
-							body: {
-								error: error.description default "",
-					{{#if giveCircuitResponse}}
-								circuitBreaker: vars.circuit update {
-									case .retryAfter! if (isOpen) -> retryAfter
-								}
-					{{/if}}
-							}											
-						}]' />
-				<flow-ref name="setResponse" doc:name="setResponse"/>
-			</when>
-			<otherwise>
-				<logger message="Exception not included in the Exceptions Array" level="DEBUG" category="com.mule.policies.circuitbreaker" doc:name="Exception not in list"/>
-				<set-variable variableName="response" doc:name="Set Response Info"
-					value='#[output application/json
-						---
-						{
-							status: 500,
-							body: {
-								error: error.description default ""
-							}
-						}]' />
-				<flow-ref name="setResponse" doc:name="setResponse"/>
-			</otherwise>
-		</choice>
-	</sub-flow>
-	
-	<!-- Set the open circuit 503 response.  Body is empty if CB info is disabled.
-		The timestamp in CB info is updated to current time, but retryAfter is calculated from the original timestamp. -->
-	<sub-flow name="processOpenCircuit">
-		<logger message="Circuit is open, so sending 503 response." level="DEBUG" category="com.mule.policies.circuitbreaker" />
-		<set-variable variableName="response" doc:name="Set Response Info"
-			value='#[output application/json
-				import update from dw::util::Values
-				var retryAfter = vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod){{{retryPeriodUnit}}}" as Period) as String
-				---
-				{
-					status: 503,					
-			{{#if giveCircuitResponse}}
-					body: {
-						circuitBreaker: vars.circuit update {
-							case .timestamp -> now()
-							case .retryAfter! -> retryAfter
-						}
-					}
-			{{/if}}			
-				}]' />
-		<flow-ref name="setResponse" doc:name="setResponse"/>
-	</sub-flow>
-	
-	<!-- Set the HTTP response: status, body [optional], and retry-after header [when OPEN] -->
-	<sub-flow name="setResponse">
-		<choice doc:name="Does response body exist?" doc:id="38126881-11b7-480d-9166-7a632e0968e5" >
-			<when expression="#[!isEmpty(vars.response.body)]">
-				<http-transform:set-response statusCode="#[vars.response.status default 503]" doc:name="Set HTTP response with body">
-					<http-transform:body><![CDATA[#[output application/json
-						---
-						vars.response.body]]]>
-					</http-transform:body>
-					<http-transform:headers><![CDATA[#[output application/java
-						var isOpen = vars.circuit.state == "OPEN" default false
-						var retryAfter = vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod){{{retryPeriodUnit}}}" as Period)
-						---
-						{                                  
-						   ("retry-after": retryAfter as String {format: "EEE, dd MMM uuuu KK:mm:ss zz"} default "") if (isOpen)
-						}]]]>
-					</http-transform:headers>
-				</http-transform:set-response>
-			</when>
-			<otherwise >
-				<set-payload value="#[null]" doc:name="Set empty body (null and */* mimeType)" mimeType="*/*"/>
-				<http-policy-transform:set-response statusCode="#[vars.response.status default 503]" doc:name="Set HTTP response without body" >
-					<http-transform:body><![CDATA[#[payload]]]></http-transform:body>
-					<http-policy-transform:headers ><![CDATA[#[output application/java
-						var isOpen = vars.circuit.state == "OPEN" default false
-						var retryAfter = vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod){{{retryPeriodUnit}}}" as Period)
-						---
-						{                                  
-						   ("retry-after": retryAfter as String {format: "EEE, dd MMM uuuu KK:mm:ss zz"} default "") if (isOpen)
-						}]]]>
-					</http-policy-transform:headers>
-				</http-policy-transform:set-response>
-			</otherwise>
-		</choice>
-	</sub-flow>
+    <!-- Update circuit state and cache it -->
+    <sub-flow name="updateCircuit">
+        <set-variable variableName="circuit" 
+            value='#[%dw 2.0
+                output application/json
+                var currentErrorCount = (vars.circuit.errorCount default 0) + 1
+                var state = if(currentErrorCount &lt; {{{failureThreshold}}}) "CLOSED" 
+                          else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + ("PT$(vars.circuit.retryPeriod default 0){{{retryPeriodUnit}}}" as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN"
+                          else "OPEN"
+                ---
+                {
+                    "failureThreshold": {{{failureThreshold}}},
+                    "retryPeriod": {{{retryPeriod}}},
+                    "retryPeriodUnit": "{{{retryPeriodUnit}}}",
+                    "state": state,
+                    "timestamp": now(),
+                    "errorCount": currentErrorCount
+                }]' doc:name="Set Circuit Breaker Info"/>
+        <logger level="DEBUG" doc:name="Updated Circuit Info" doc:id="48d22930-92e1-42eb-b446-bb846bf08c91" message='#[vars.circuit default {}]' category="com.mule.policies.circuitbreaker" />
+        <os:store key="${apiId}" objectStore="cbstore" doc:name="Save status to OS">
+            <os:value>
+                #[vars.circuit]
+            </os:value>
+        </os:store>
+    </sub-flow>
+    
+    <!-- Evaluate circuit state based on API response's status code.  If CB info is disabled, then body is API response body.  
+        If CB info is enabled, then body is CB field and data field with API response body. -->
+    <sub-flow name="evaluateHttpResponse">
+        <choice doc:name="Is status code in CB list?">
+            <when expression='#[output application/json 
+                                var httpCodesArray=(("{{{httpCodesArray}}}" replace " " with "") splitBy  ",") as Array 
+                                --- 
+                                (httpCodesArray contains (attributes.statusCode as String))]'>
+                <logger message="HTTP Status Code is included in the HTTP Codes Array" level="DEBUG" category="com.mule.policies.circuitbreaker" doc:name="HTTP Status Code in list"/>
+                <flow-ref name="updateCircuit" doc:name="updateCircuit"/>
+                <set-variable variableName="response" doc:name="Set Response Info"
+                    value='#[output application/json
+                    {{#if giveCircuitResponse}}
+                        import update from dw::util::Values
+                        var isOpen = vars.circuit.state == "OPEN" default false
+                        var retryAfter = vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod){{{retryPeriodUnit}}}" as Period) as String
+                    {{/if}}
+                        ---
+                        {   
+                            status: 503,
+                    {{#if giveCircuitResponse}}
+                            body: {
+                                (data: payload) if (!isEmpty(payload)),
+                                circuitBreaker: vars.circuit update {
+                                    case .errorStatusCode! -> attributes.statusCode as String
+                                    case .retryAfter! if (isOpen) -> retryAfter
+                                }
+                            }
+                    {{else}}
+                            body: payload
+                    {{/if}}                             
+                        }]' />
+                <flow-ref name="setResponse" doc:name="setResponse"/>
+            </when>
+            <otherwise>
+                <logger message="HTTP Status Code not included in the HTTP Codes Array" level="DEBUG" category="com.mule.policies.circuitbreaker" doc:name="HTTP Status Code not in list"/>
+            </otherwise>
+        </choice>
+    </sub-flow>
+    
+    <!-- Evaluate circuit state based on error thrown from API.  This always returns error field in body and will add CB info if enabled. -->
+    <sub-flow name="evaluateErrorObject">
+        <flow-ref name="errorLogger" doc:name="errorLogger"/>
+        <choice doc:name="Is exception in CB list?">
+            <when expression='#[output application/json var exceptionsArray=(("{{{exceptionsArray}}}" replace " " with "") splitBy  ",") as Array --- (exceptionsArray contains (error.errorType.namespace ++ ":" ++ error.errorType.identifier) ) or ( (sizeOf(exceptionsArray) == 1) and (exceptionsArray contains "ANY"))]'>
+                
+                <logger level="DEBUG" doc:name="Exception in list" doc:id="d5857c44-0728-4ca9-a78e-6bb2491d6c02" message="Exception is included in the Exceptions Array" category="com.mule.policies.circuitbreaker" />
+                <flow-ref name="updateCircuit" doc:name="updateCircuit"/>
+                <set-variable variableName="response" doc:name="Set Response Info"
+                    value='#[output application/json
+                    {{#if giveCircuitResponse}}
+                        import update from dw::util::Values
+                        var isOpen = vars.circuit.state == "OPEN" default false
+                        var retryAfter = vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod){{{retryPeriodUnit}}}" as Period) as String
+                    {{/if}}
+                        ---
+                        {           
+                            status: 503,
+                            body: {
+                                error: error.description default "",
+                    {{#if giveCircuitResponse}}
+                                circuitBreaker: vars.circuit update {
+                                    case .retryAfter! if (isOpen) -> retryAfter
+                                }
+                    {{/if}}
+                            }                                           
+                        }]' />
+                <flow-ref name="setResponse" doc:name="setResponse"/>
+            </when>
+            <otherwise>
+                <logger message="Exception not included in the Exceptions Array" level="DEBUG" category="com.mule.policies.circuitbreaker" doc:name="Exception not in list"/>
+                <set-variable variableName="response" doc:name="Set Response Info"
+                    value='#[output application/json
+                        ---
+                        {
+                            status: 500,
+                            body: {
+                                error: error.description default ""
+                            }
+                        }]' />
+                <flow-ref name="setResponse" doc:name="setResponse"/>
+            </otherwise>
+        </choice>
+    </sub-flow>
+    
+    <!-- Set the open circuit 503 response.  Body is empty if CB info is disabled.
+        The timestamp in CB info is updated to current time, but retryAfter is calculated from the original timestamp. -->
+    <sub-flow name="processOpenCircuit">
+        <logger message="Circuit is open, so sending 503 response." level="DEBUG" category="com.mule.policies.circuitbreaker" />
+        <set-variable variableName="response" doc:name="Set Response Info"
+            value='#[output application/json
+                import update from dw::util::Values
+                var retryAfter = vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod){{{retryPeriodUnit}}}" as Period) as String
+                ---
+                {
+                    status: 503,                    
+            {{#if giveCircuitResponse}}
+                    body: {
+                        circuitBreaker: vars.circuit update {
+                            case .timestamp -> now()
+                            case .retryAfter! -> retryAfter
+                        }
+                    }
+            {{/if}}         
+                }]' />
+        <flow-ref name="setResponse" doc:name="setResponse"/>
+    </sub-flow>
+    
+    <!-- Set the HTTP response: status, body [optional], and retry-after header [when OPEN] -->
+    <sub-flow name="setResponse">
+        <choice doc:name="Does response body exist?" doc:id="38126881-11b7-480d-9166-7a632e0968e5" >
+            <when expression="#[!isEmpty(vars.response.body)]">
+                <http-transform:set-response statusCode="#[vars.response.status default 503]" doc:name="Set HTTP response with body">
+                    <http-transform:body><![CDATA[#[output application/json
+                        ---
+                        vars.response.body]]]>
+                    </http-transform:body>
+                    <http-transform:headers><![CDATA[#[output application/java
+                        var isOpen = vars.circuit.state == "OPEN" default false
+                        var retryAfter = vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod){{{retryPeriodUnit}}}" as Period)
+                        ---
+                        {                                  
+                           ("retry-after": retryAfter as String {format: "EEE, dd MMM uuuu KK:mm:ss zz"} default "") if (isOpen)
+                        }]]]>
+                    </http-transform:headers>
+                </http-transform:set-response>
+            </when>
+            <otherwise >
+                <set-payload value="#[null]" doc:name="Set empty body (null and */* mimeType)" mimeType="*/*"/>
+                <http-policy-transform:set-response statusCode="#[vars.response.status default 503]" doc:name="Set HTTP response without body" >
+                    <http-transform:body><![CDATA[#[payload]]]></http-transform:body>
+                    <http-policy-transform:headers ><![CDATA[#[output application/java
+                        var isOpen = vars.circuit.state == "OPEN" default false
+                        var retryAfter = vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod){{{retryPeriodUnit}}}" as Period)
+                        ---
+                        {                                  
+                           ("retry-after": retryAfter as String {format: "EEE, dd MMM uuuu KK:mm:ss zz"} default "") if (isOpen)
+                        }]]]>
+                    </http-policy-transform:headers>
+                </http-policy-transform:set-response>
+            </otherwise>
+        </choice>
+    </sub-flow>
 </mule>

--- a/src/main/mule/template.xml
+++ b/src/main/mule/template.xml
@@ -31,7 +31,7 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
             </try>
             <choice>
                 <!--  Condition to allow the application call  -->
-                <when expression="#[((sizeOf(vars.circuit default '') == 0) or ((vars.circuit.timestamp default 0) + (&quot;PT$(vars.circuit.retryPeriod default 0)S&quot; as Period) &lt; now())) or ((vars.circuit.errorCount default 0) &lt; {{{failureThreshold}}}) or vars.circuit.state == &quot;HALF-OPEN&quot; ]">
+                <when expression='#[((sizeOf(vars.circuit default "") == 0) or ((vars.circuit.timestamp default 0) + ("PT$(vars.circuit.retryPeriod default 0)S" as Period) &lt; now())) or ((vars.circuit.errorCount default 0) &lt; {{{failureThreshold}}}) or vars.circuit.state == "HALF-OPEN" ]'>
                     <try>
                         <logger message="http-policy:execute-next" level="DEBUG" category="com.mule.policies.circuitbreaker"/>
                         <http-policy:execute-next />
@@ -58,7 +58,7 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                                       output application/json
                                       var currentErrorCount = (vars.circuit.errorCount default 0) + 1
                                       var state = if(currentErrorCount &lt; {{{failureThreshold}}}) "CLOSED" 
-                                                  else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + (&quot;PT$(vars.circuit.retryPeriod default 0)S&quot; as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN" 
+                                                  else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + ("PT$(vars.circuit.retryPeriod default 0)S" as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN"
                                                   else "OPEN"
                                       ---
                                       {
@@ -93,7 +93,7 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                                               output application/json
                                               var currentErrorCount = (vars.circuit.errorCount default 0) + 1
                                               var state = if(currentErrorCount &lt; {{{failureThreshold}}}) "CLOSED" 
-                                                          else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + (&quot;PT$(vars.circuit.retryPeriod default 0)S&quot; as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN" 
+                                                          else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + ("PT$(vars.circuit.retryPeriod default 0)S" as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN"
                                                           else "OPEN"
                                               ---
                                               {

--- a/src/main/mule/template.xml
+++ b/src/main/mule/template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<mule xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mulesoft.org/schema/mule/core"
-      xmlns:os="http://www.mulesoft.org/schema/mule/os" xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns:http-policy="http://www.mulesoft.org/schema/mule/http-policy"
-      xmlns:http-transform="http://www.mulesoft.org/schema/mule/http-policy-transform" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core
+<mule xmlns:http-policy-transform="http://www.mulesoft.org/schema/mule/http-policy-transform" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:os="http://www.mulesoft.org/schema/mule/os" xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xmlns:http-policy="http://www.mulesoft.org/schema/mule/http-policy" xmlns:http-transform="http://www.mulesoft.org/schema/mule/http-policy-transform" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core
 http://www.mulesoft.org/schema/mule/core/current/mule.xsd
 http://www.mulesoft.org/schema/mule/http
 http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
@@ -23,11 +23,12 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
     <http-policy:proxy name="{{{policyId}}}-custom-policy">
         <http-policy:source>
             <flow-ref name="getStatusFromCache" />
-            <choice>
-                
+            <choice>                
                 <when expression='#[ ((sizeOf(vars.circuit default "") == 0) or ((vars.circuit.timestamp default 0) + ("PT$(vars.circuit.retryPeriod default 0){{{retryPeriodUnit}}}" as Period) &lt; now())) or ((vars.circuit.errorCount default 0) &lt; {{{failureThreshold}}}) or vars.circuit.state == "HALF-OPEN" ]'>
 					<!-- Circuit is closed or half-open -->
+				{{#if evaluateErrorObject}}
                     <try>
+				{{/if}}
                         <logger message="http-policy:execute-next" level="DEBUG" category="com.mule.policies.circuitbreaker"/>
                         <http-policy:execute-next />
                         <logger message="#[attributes]" level="DEBUG" category="com.mule.policies.circuitbreaker"/>
@@ -40,17 +41,17 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                                 <os:remove key="${apiId}" objectStore="cbstore"  />
                             </otherwise>
                         </choice>
-                        {{#if evaluateHttpResponse}}
+				{{#if evaluateHttpResponse}}
                             <flow-ref name="evaluateHttpResponse" />
-                        {{/if}}
-                        {{#if evaluateErrorObject}}
+				{{/if}}
+				{{#if evaluateErrorObject}}
                             <error-handler>
                                 <on-error-propagate type="ANY" logException="true">
                                     <flow-ref name="evaluateErrorObject" />
                                 </on-error-propagate>
-                            </error-handler>
-                        {{/if}}    
+                            </error-handler>  
                     </try>
+				{{/if}}
                 </when>
                 <otherwise>
 					<!-- Circuit open -->
@@ -60,7 +61,7 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
         </http-policy:source>
     </http-policy:proxy>
 
-	<!-- SUBFLOWS - Used in Studio UI -->
+	<!-- SUBFLOWS: can be used in Studio UI -->
 	
 	<!-- Get circuit's previous state from cache -->
 	<sub-flow name="getStatusFromCache">
@@ -97,6 +98,7 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
 					"timestamp": now(),
 					"errorCount": currentErrorCount
 				}]' doc:name="Set Circuit Breaker Info"/>
+		<logger level="DEBUG" doc:name="Updated Circuit Info" doc:id="48d22930-92e1-42eb-b446-bb846bf08c91" message='#[vars.circuit default {}]' category="com.mule.policies.circuitbreaker" />
 		<os:store key="${apiId}" objectStore="cbstore" doc:name="Save status to OS">
 			<os:value>
 				#[vars.circuit]
@@ -104,23 +106,37 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
 		</os:store>
 	</sub-flow>
 	
-	<!-- Evaluate circuit state based on API response's status code -->
+	<!-- Evaluate circuit state based on API response's status code.  If CB info is disabled, then body is API response body.  
+		If CB info is enabled, then body is CB field and data field with API response body. -->
 	<sub-flow name="evaluateHttpResponse">
 		<choice doc:name="Is status code in CB list?">
-			<when expression="#[output application/json 
-								var httpCodesArray=(({{{httpCodesArray}}} replace ' ' with '') splitBy  ',') as Array 
+			<when expression='#[output application/json 
+								var httpCodesArray=(("{{{httpCodesArray}}}" replace " " with "") splitBy  ",") as Array 
 								--- 
-								(httpCodesArray contains (attributes.statusCode as String))]">
-
+								(httpCodesArray contains (attributes.statusCode as String))]'>
+				<logger message="HTTP Status Code is included in the HTTP Codes Array" level="DEBUG" category="com.mule.policies.circuitbreaker" doc:name="HTTP Status Code in list"/>
 				<flow-ref name="updateCircuit" doc:name="updateCircuit"/>
 				<set-variable variableName="response" doc:name="Set Response Info"
 					value='#[output application/json
+					{{#if giveCircuitResponse}}
+						import update from dw::util::Values
+						var isOpen = vars.circuit.state == "OPEN" default false
+						var retryAfter = vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod){{{retryPeriodUnit}}}" as Period) as String
+					{{/if}}
 						---
-						{
+						{	
 							status: 503,
+					{{#if giveCircuitResponse}}
 							body: {
-								circuitBreaker: vars.circuit ++ "error": { "code": "$(attributes.statusCode)", ("reasonPhrase": "$(attributes.reasonPhrase)") if (!isEmpty(attributes.reasonPhrase)) }
+								(data: payload) if (!isEmpty(payload)),
+								circuitBreaker: vars.circuit update {
+									case .errorStatusCode! -> attributes.statusCode as String
+									case .retryAfter! if (isOpen) -> retryAfter
+								}
 							}
+					{{else}}
+							body: payload
+					{{/if}}								
 						}]' />
 				<flow-ref name="setResponse" doc:name="setResponse"/>
 			</when>
@@ -130,19 +146,32 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
 		</choice>
 	</sub-flow>
 	
-	<!-- Evaluate circuit state based on error thrown from API -->
+	<!-- Evaluate circuit state based on error thrown from API.  This always returns error field in body and will add CB info if enabled. -->
 	<sub-flow name="evaluateErrorObject">
 		<flow-ref name="errorLogger" doc:name="errorLogger"/>
 		<choice doc:name="Is exception in CB list?">
-			<when expression="#[output application/json var exceptionsArray=(({{{exceptionsArray}}} replace ' ' with '') splitBy  ',') as Array --- (exceptionsArray contains (error.errorType.namespace ++ ':' ++ error.errorType.identifier) ) or ( (sizeOf(exceptionsArray) == 1) and (exceptionsArray contains 'ANY'))]">
+			<when expression='#[output application/json var exceptionsArray=(("{{{exceptionsArray}}}" replace " " with "") splitBy  ",") as Array --- (exceptionsArray contains (error.errorType.namespace ++ ":" ++ error.errorType.identifier) ) or ( (sizeOf(exceptionsArray) == 1) and (exceptionsArray contains "ANY"))]'>
 				
+				<logger level="DEBUG" doc:name="Exception in list" doc:id="d5857c44-0728-4ca9-a78e-6bb2491d6c02" message="Exception is included in the Exceptions Array" category="com.mule.policies.circuitbreaker" />
 				<flow-ref name="updateCircuit" doc:name="updateCircuit"/>
 				<set-variable variableName="response" doc:name="Set Response Info"
 					value='#[output application/json
+					{{#if giveCircuitResponse}}
+						import update from dw::util::Values
+						var isOpen = vars.circuit.state == "OPEN" default false
+						var retryAfter = vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod){{{retryPeriodUnit}}}" as Period) as String
+					{{/if}}
 						---
-						{
+						{			
 							status: 503,
-							body: { "circuitBreaker": vars.circuit ++ "error": "$(error.description)" }
+							body: {
+								error: error.description default "",
+					{{#if giveCircuitResponse}}
+								circuitBreaker: vars.circuit update {
+									case .retryAfter! if (isOpen) -> retryAfter
+								}
+					{{/if}}
+							}											
 						}]' />
 				<flow-ref name="setResponse" doc:name="setResponse"/>
 			</when>
@@ -153,43 +182,71 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
 						---
 						{
 							status: 500,
-							body: error.description
+							body: {
+								error: error.description default ""
+							}
 						}]' />
 				<flow-ref name="setResponse" doc:name="setResponse"/>
 			</otherwise>
 		</choice>
 	</sub-flow>
 	
-	<!-- Set the open circuit 503 response with the retry-after header -->
+	<!-- Set the open circuit 503 response.  Body is empty if CB info is disabled.
+		The timestamp in CB info is updated to current time, but retryAfter is calculated from the original timestamp. -->
 	<sub-flow name="processOpenCircuit">
 		<logger message="Circuit is open, so sending 503 response." level="DEBUG" category="com.mule.policies.circuitbreaker" />
 		<set-variable variableName="response" doc:name="Set Response Info"
 			value='#[output application/json
 				import update from dw::util::Values
+				var retryAfter = vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod){{{retryPeriodUnit}}}" as Period) as String
 				---
 				{
-					status: 503,
-					body: "circuitBreaker": (vars.circuit update "timestamp" with now())
-						++ "error": "The circuit is still open, not propagating new requests until " 
-						++ vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod){{{retryPeriodUnit}}}" as Period)
+					status: 503,					
+			{{#if giveCircuitResponse}}
+					body: {
+						circuitBreaker: vars.circuit update {
+							case .timestamp -> now()
+							case .retryAfter! -> retryAfter
+						}
+					}
+			{{/if}}			
 				}]' />
 		<flow-ref name="setResponse" doc:name="setResponse"/>
 	</sub-flow>
 	
 	<!-- Set the HTTP response: status, body [optional], and retry-after header [when OPEN] -->
 	<sub-flow name="setResponse">
-		<http-transform:set-response
-			statusCode="#[vars.response.status default 503]" doc:name="Set HTTP response">
-			<http-transform:body><![CDATA[#[output application/json
-				---
-				vars.response.body default null]]]>
-			</http-transform:body>
-			<http-transform:headers ><![CDATA[#[output application/java
-var retryAfter = vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod){{{retryPeriodUnit}}}" as Period)
----
-{                                  
-   ("retry-after": retryAfter as String {format: "EEE, dd MMM uuuu KK:mm:ss zz"} default "") if (vars.circuit.state == "OPEN" default false)
-}]]]></http-transform:headers>
-		</http-transform:set-response>
+		<choice doc:name="Does response body exist?" doc:id="38126881-11b7-480d-9166-7a632e0968e5" >
+			<when expression="#[!isEmpty(vars.response.body)]">
+				<http-transform:set-response statusCode="#[vars.response.status default 503]" doc:name="Set HTTP response with body">
+					<http-transform:body><![CDATA[#[output application/json
+						---
+						vars.response.body]]]>
+					</http-transform:body>
+					<http-transform:headers><![CDATA[#[output application/java
+						var isOpen = vars.circuit.state == "OPEN" default false
+						var retryAfter = vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod){{{retryPeriodUnit}}}" as Period)
+						---
+						{                                  
+						   ("retry-after": retryAfter as String {format: "EEE, dd MMM uuuu KK:mm:ss zz"} default "") if (isOpen)
+						}]]]>
+					</http-transform:headers>
+				</http-transform:set-response>
+			</when>
+			<otherwise >
+				<set-payload value="#[null]" doc:name="Set empty body (null and */* mimeType)" mimeType="*/*"/>
+				<http-policy-transform:set-response statusCode="#[vars.response.status default 503]" doc:name="Set HTTP response without body" >
+					<http-transform:body><![CDATA[#[payload]]]></http-transform:body>
+					<http-policy-transform:headers ><![CDATA[#[output application/java
+						var isOpen = vars.circuit.state == "OPEN" default false
+						var retryAfter = vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod){{{retryPeriodUnit}}}" as Period)
+						---
+						{                                  
+						   ("retry-after": retryAfter as String {format: "EEE, dd MMM uuuu KK:mm:ss zz"} default "") if (isOpen)
+						}]]]>
+					</http-policy-transform:headers>
+				</http-policy-transform:set-response>
+			</otherwise>
+		</choice>
 	</sub-flow>
 </mule>

--- a/src/main/mule/template.xml
+++ b/src/main/mule/template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:os="http://www.mulesoft.org/schema/mule/os"
-      xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns:http-policy="http://www.mulesoft.org/schema/mule/http-policy" xmlns:http-transform="http://www.mulesoft.org/schema/mule/http-policy-transform"
-      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core
+<mule xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:os="http://www.mulesoft.org/schema/mule/os" xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns:http-policy="http://www.mulesoft.org/schema/mule/http-policy"
+      xmlns:http-transform="http://www.mulesoft.org/schema/mule/http-policy-transform" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core
 http://www.mulesoft.org/schema/mule/core/current/mule.xsd
 http://www.mulesoft.org/schema/mule/http
 http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
@@ -18,20 +18,15 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
     {{else}}
         <os:object-store name="cbstore" persistent="true" entryTtl="1" entryTtlUnit="HOURS" />
     {{/if}}
+	
+	<!-- Main Policy -->
     <http-policy:proxy name="{{{policyId}}}-custom-policy">
         <http-policy:source>
-            <try>
-                <!-- Checking Cache for OPEN| HALF-OPEN stored value -->
-                <os:retrieve key="${apiId}" target="circuit"  objectStore="cbstore" />
-                <error-handler>
-                    <on-error-continue type="OS:KEY_NOT_FOUND" logException="false" >
-                        <logger message="Circuit is CLOSED. Continue processing. Before execution" level="DEBUG" category="com.mule.policies.circuitbreaker" />
-                    </on-error-continue>
-                </error-handler>
-            </try>
+            <flow-ref name="getStatusFromCache" />
             <choice>
-                <!--  Condition to allow the application call  -->
-                <when expression='#[((sizeOf(vars.circuit default "") == 0) or ((vars.circuit.timestamp default 0) + ("PT$(vars.circuit.retryPeriod default 0){{{retryPeriodUnit}}}" as Period) &lt; now())) or ((vars.circuit.errorCount default 0) &lt; {{{failureThreshold}}}) or vars.circuit.state == "HALF-OPEN" ]'>
+                
+                <when expression='#[ ((sizeOf(vars.circuit default "") == 0) or ((vars.circuit.timestamp default 0) + ("PT$(vars.circuit.retryPeriod default 0){{{retryPeriodUnit}}}" as Period) &lt; now())) or ((vars.circuit.errorCount default 0) &lt; {{{failureThreshold}}}) or vars.circuit.state == "HALF-OPEN" ]'>
+					<!-- Circuit is closed or half-open -->
                     <try>
                         <logger message="http-policy:execute-next" level="DEBUG" category="com.mule.policies.circuitbreaker"/>
                         <http-policy:execute-next />
@@ -46,103 +41,155 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                             </otherwise>
                         </choice>
                         {{#if evaluateHttpResponse}}
-                            <choice>
-                                <when expression="#[%dw 2.0 
-                                                    output application/json 
-                                                    var httpCodesArray=(({{{httpCodesArray}}} replace ' ' with '') splitBy  ',') as Array 
-                                                    --- 
-                                                    (httpCodesArray contains (attributes.statusCode as String))]">
-
-                                    <!-- Trip the Circuit -->
-                                    <set-variable value='#[%dw 2.0
-                                      output application/json
-                                      var currentErrorCount = (vars.circuit.errorCount default 0) + 1
-                                      var state = if(currentErrorCount &lt; {{{failureThreshold}}}) "CLOSED" 
-                                                  else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + ("PT$(vars.circuit.retryPeriod default 0){{{retryPeriodUnit}}}" as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN"
-                                                  else "OPEN"
-                                      ---
-                                      {
-                                        "failureThreshold": {{{failureThreshold}}},
-                                        "retryPeriod": {{{retryPeriod}}},
-                                        "retryPeriodUnit": "{{{retryPeriodUnit}}}",
-                                        "state": state,
-                                        "timestamp": now(),
-                                        "errorCount": currentErrorCount
-                                       }]' variableName="circuit" />
-                                    <os:store key="${apiId}" objectStore="cbstore">
-                                        <os:value>
-                                            #[vars.circuit]
-                                        </os:value>
-                                    </os:store>
-                                    <http-transform:set-response statusCode="503">
-                                        <http-transform:body>#[%dw 2.0 output application/json --- "circuitBreaker": vars.circuit ++ "error": { "code": "$(attributes.statusCode)", ("reasonPhrase": "$(attributes.reasonPhrase)") if (!isEmpty(attributes.reasonPhrase)) }]</http-transform:body>
-                                    </http-transform:set-response>
-                                </when>
-                                <otherwise>
-                                    <logger message="HTTP Status Code not included in the HTTP Codes Array" level="DEBUG" category="com.mule.policies.circuitbreaker" />
-                                </otherwise>
-                            </choice>
+                            <flow-ref name="evaluateHttpResponse" />
                         {{/if}}
                         {{#if evaluateErrorObject}}
                             <error-handler>
                                 <on-error-propagate type="ANY" logException="true">
-                                    <flow-ref name="error-logger" />
-                                    <choice>
-                                        <when expression="#[%dw 2.0 output application/json var exceptionsArray=(({{{exceptionsArray}}} replace ' ' with '') splitBy  ',') as Array --- (exceptionsArray contains (error.errorType.namespace ++ ':' ++ error.errorType.identifier) ) or ( (sizeOf(exceptionsArray) == 1) and (exceptionsArray contains 'ANY'))]">
-                                            <!-- Trip the Circuit -->
-                                            <set-variable value='#[%dw 2.0
-                                              output application/json
-                                              var currentErrorCount = (vars.circuit.errorCount default 0) + 1
-                                              var state = if(currentErrorCount &lt; {{{failureThreshold}}}) "CLOSED" 
-                                                          else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + ("PT$(vars.circuit.retryPeriod default 0){{{retryPeriodUnit}}}" as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN"
-                                                          else "OPEN"
-                                              ---
-                                              {
-                                                "failureThreshold": {{{failureThreshold}}},
-                                                "retryPeriod": {{{retryPeriod}}},
-                                                "retryPeriodUnit": "{{{retryPeriodUnit}}}",
-                                                "state": state,
-                                                "timestamp": now(),
-                                                "errorCount": currentErrorCount
-                                               }]'
-                                                          variableName="circuit" />
-                                            <os:store key="${apiId}" objectStore="cbstore">
-                                                <os:value>
-                                                    #[vars.circuit]
-                                                </os:value>
-                                            </os:store>
-                                            <http-transform:set-response statusCode="503">
-                                                <http-transform:body>#[%dw 2.0 output application/json --- "circuitBreaker": vars.circuit ++ "error": "$(error.description)"]</http-transform:body>
-                                            </http-transform:set-response>
-                                        </when>
-                                        <otherwise>
-                                            <logger message="Exception not included in the Exceptions Array" level="DEBUG" category="com.mule.policies.circuitbreaker" />
-                                            <http-transform:set-response statusCode="500">
-                                                <http-transform:body>#[%dw 2.0 output application/json --- error.description]</http-transform:body>
-                                            </http-transform:set-response>
-                                        </otherwise>
-                                    </choice>
+                                    <flow-ref name="evaluateErrorObject" />
                                 </on-error-propagate>
                             </error-handler>
                         {{/if}}    
                     </try>
                 </when>
                 <otherwise>
-                    <http-transform:set-response statusCode="503">
-                        <http-transform:body>#[%dw 2.0 
-                                                import update from dw::util::Values
-                                                output application/json 
-                                                ---
-                                                "circuitBreaker": (vars.circuit update "timestamp" with now())
-                                                ++ "error": "The circuit is still open, not propagating new requests until " 
-                                                ++ vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod){{{retryPeriodUnit}}}" as Period)]</http-transform:body>
-                    </http-transform:set-response>
+					<!-- Circuit open -->
+                    <flow-ref name="processOpenCircuit" />
                 </otherwise>
             </choice>
         </http-policy:source>
     </http-policy:proxy>
 
-    <flow name="error-logger">
-        <logger level="ERROR" message="#[%dw 2.0 output application/json --- errorMessage:  (error.errorType.namespace ++ ':' ++ error.errorType.identifier)]" category="com.mule.policies.circuitbreaker" />
-    </flow>
+	<!-- SUBFLOWS - Used in Studio UI -->
+	
+	<!-- Get circuit's previous state from cache -->
+	<sub-flow name="getStatusFromCache">
+		<try>
+			<!-- Checking Cache for OPEN| HALF-OPEN stored value -->
+			<os:retrieve key="${apiId}" target="circuit"  objectStore="cbstore" doc:name="Get status from OS"/>
+			<error-handler>
+				<on-error-continue type="OS:KEY_NOT_FOUND" logException="false" >
+					<logger message="Circuit is CLOSED. Continue processing. Before execution" level="DEBUG" category="com.mule.policies.circuitbreaker" doc:name="Logger"/>
+				</on-error-continue>
+			</error-handler>
+		</try>
+	</sub-flow>
+	
+    <sub-flow name="errorLogger">
+		<logger level="ERROR" message="#[%dw 2.0 output application/json --- errorMessage:  (error.errorType.namespace ++ ':' ++ error.errorType.identifier)]" category="com.mule.policies.circuitbreaker" doc:name="Log error"/>
+	</sub-flow>
+
+	<!-- Update circuit state and cache it -->
+	<sub-flow name="updateCircuit">
+		<set-variable variableName="circuit" 
+			value='#[%dw 2.0
+				output application/json
+				var currentErrorCount = (vars.circuit.errorCount default 0) + 1
+				var state = if(currentErrorCount &lt; {{{failureThreshold}}}) "CLOSED" 
+						  else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + ("PT$(vars.circuit.retryPeriod default 0){{{retryPeriodUnit}}}" as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN"
+						  else "OPEN"
+				---
+				{
+					"failureThreshold": {{{failureThreshold}}},
+					"retryPeriod": {{{retryPeriod}}},
+					"retryPeriodUnit": "{{{retryPeriodUnit}}}",
+					"state": state,
+					"timestamp": now(),
+					"errorCount": currentErrorCount
+				}]' doc:name="Set Circuit Breaker Info"/>
+		<os:store key="${apiId}" objectStore="cbstore" doc:name="Save status to OS">
+			<os:value>
+				#[vars.circuit]
+			</os:value>
+		</os:store>
+	</sub-flow>
+	
+	<!-- Evaluate circuit state based on API response's status code -->
+	<sub-flow name="evaluateHttpResponse">
+		<choice doc:name="Is status code in CB list?">
+			<when expression="#[output application/json 
+								var httpCodesArray=(({{{httpCodesArray}}} replace ' ' with '') splitBy  ',') as Array 
+								--- 
+								(httpCodesArray contains (attributes.statusCode as String))]">
+
+				<flow-ref name="updateCircuit" doc:name="updateCircuit"/>
+				<set-variable variableName="response" doc:name="Set Response Info"
+					value='#[output application/json
+						---
+						{
+							status: 503,
+							body: {
+								circuitBreaker: vars.circuit ++ "error": { "code": "$(attributes.statusCode)", ("reasonPhrase": "$(attributes.reasonPhrase)") if (!isEmpty(attributes.reasonPhrase)) }
+							}
+						}]' />
+				<flow-ref name="setResponse" doc:name="setResponse"/>
+			</when>
+			<otherwise>
+				<logger message="HTTP Status Code not included in the HTTP Codes Array" level="DEBUG" category="com.mule.policies.circuitbreaker" doc:name="HTTP Status Code not in list"/>
+			</otherwise>
+		</choice>
+	</sub-flow>
+	
+	<!-- Evaluate circuit state based on error thrown from API -->
+	<sub-flow name="evaluateErrorObject">
+		<flow-ref name="errorLogger" doc:name="errorLogger"/>
+		<choice doc:name="Is exception in CB list?">
+			<when expression="#[output application/json var exceptionsArray=(({{{exceptionsArray}}} replace ' ' with '') splitBy  ',') as Array --- (exceptionsArray contains (error.errorType.namespace ++ ':' ++ error.errorType.identifier) ) or ( (sizeOf(exceptionsArray) == 1) and (exceptionsArray contains 'ANY'))]">
+				
+				<flow-ref name="updateCircuit" doc:name="updateCircuit"/>
+				<set-variable variableName="response" doc:name="Set Response Info"
+					value='#[output application/json
+						---
+						{
+							status: 503,
+							body: { "circuitBreaker": vars.circuit ++ "error": "$(error.description)" }
+						}]' />
+				<flow-ref name="setResponse" doc:name="setResponse"/>
+			</when>
+			<otherwise>
+				<logger message="Exception not included in the Exceptions Array" level="DEBUG" category="com.mule.policies.circuitbreaker" doc:name="Exception not in list"/>
+				<set-variable variableName="response" doc:name="Set Response Info"
+					value='#[output application/json
+						---
+						{
+							status: 500,
+							body: error.description
+						}]' />
+				<flow-ref name="setResponse" doc:name="setResponse"/>
+			</otherwise>
+		</choice>
+	</sub-flow>
+	
+	<!-- Set the open circuit 503 response with the retry-after header -->
+	<sub-flow name="processOpenCircuit">
+		<logger message="Circuit is open, so sending 503 response." level="DEBUG" category="com.mule.policies.circuitbreaker" />
+		<set-variable variableName="response" doc:name="Set Response Info"
+			value='#[output application/json
+				import update from dw::util::Values
+				---
+				{
+					status: 503,
+					body: "circuitBreaker": (vars.circuit update "timestamp" with now())
+						++ "error": "The circuit is still open, not propagating new requests until " 
+						++ vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod){{{retryPeriodUnit}}}" as Period)
+				}]' />
+		<flow-ref name="setResponse" doc:name="setResponse"/>
+	</sub-flow>
+	
+	<!-- Set the HTTP response: status, body [optional], and retry-after header [when OPEN] -->
+	<sub-flow name="setResponse">
+		<http-transform:set-response
+			statusCode="#[vars.response.status default 503]" doc:name="Set HTTP response">
+			<http-transform:body><![CDATA[#[output application/json
+				---
+				vars.response.body default null]]]>
+			</http-transform:body>
+			<http-transform:headers ><![CDATA[#[output application/java
+var retryAfter = vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod){{{retryPeriodUnit}}}" as Period)
+---
+{                                  
+   ("retry-after": retryAfter as String {format: "EEE, dd MMM uuuu KK:mm:ss zz"} default "") if (vars.circuit.state == "OPEN" default false)
+}]]]></http-transform:headers>
+		</http-transform:set-response>
+	</sub-flow>
 </mule>

--- a/src/main/mule/template.xml
+++ b/src/main/mule/template.xml
@@ -121,9 +121,6 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                                         </otherwise>
                                     </choice>
                                 </on-error-propagate>
-                                <on-error-continue type="OS:KEY_NOT_FOUND" logException="false">
-                                    <logger message="Circuit state is CLOSED. Continue processing."  level="DEBUG" category="com.mule.policies.circuitbreaker"/>
-                                </on-error-continue>
                             </error-handler>
                         {{/if}}    
                     </try>

--- a/src/main/mule/template.xml
+++ b/src/main/mule/template.xml
@@ -74,7 +74,7 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                                         </os:value>
                                     </os:store>
                                     <http-transform:set-response statusCode="503">
-                                        <http-transform:body>#[%dw 2.0 output application/json --- "circuitBreaker": vars.circuit ++ "error": { "code": "$(attributes.statusCode)", "reasonPhrase": "$(attributes.reasonPhrase)"}]</http-transform:body>
+                                        <http-transform:body>#[%dw 2.0 output application/json --- "circuitBreaker": vars.circuit ++ "error": { "code": "$(attributes.statusCode)", ("reasonPhrase": "$(attributes.reasonPhrase)") if (!isEmpty(attributes.reasonPhrase)) }]</http-transform:body>
                                     </http-transform:set-response>
                                 </when>
                                 <otherwise>

--- a/src/main/mule/template.xml
+++ b/src/main/mule/template.xml
@@ -31,7 +31,7 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
             </try>
             <choice>
                 <!--  Condition to allow the application call  -->
-                <when expression='#[((sizeOf(vars.circuit default "") == 0) or ((vars.circuit.timestamp default 0) + ("PT$(vars.circuit.retryPeriod default 0)S" as Period) &lt; now())) or ((vars.circuit.errorCount default 0) &lt; {{{failureThreshold}}}) or vars.circuit.state == "HALF-OPEN" ]'>
+                <when expression='#[((sizeOf(vars.circuit default "") == 0) or ((vars.circuit.timestamp default 0) + ("PT$(vars.circuit.retryPeriod default 0){{{retryPeriodUnit}}}" as Period) &lt; now())) or ((vars.circuit.errorCount default 0) &lt; {{{failureThreshold}}}) or vars.circuit.state == "HALF-OPEN" ]'>
                     <try>
                         <logger message="http-policy:execute-next" level="DEBUG" category="com.mule.policies.circuitbreaker"/>
                         <http-policy:execute-next />
@@ -58,12 +58,13 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                                       output application/json
                                       var currentErrorCount = (vars.circuit.errorCount default 0) + 1
                                       var state = if(currentErrorCount &lt; {{{failureThreshold}}}) "CLOSED" 
-                                                  else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + ("PT$(vars.circuit.retryPeriod default 0)S" as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN"
+                                                  else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + ("PT$(vars.circuit.retryPeriod default 0){{{retryPeriodUnit}}}" as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN"
                                                   else "OPEN"
                                       ---
                                       {
                                         "failureThreshold": {{{failureThreshold}}},
                                         "retryPeriod": {{{retryPeriod}}},
+                                        "retryPeriodUnit": "{{{retryPeriodUnit}}}",
                                         "state": state,
                                         "timestamp": now(),
                                         "errorCount": currentErrorCount
@@ -93,12 +94,13 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                                               output application/json
                                               var currentErrorCount = (vars.circuit.errorCount default 0) + 1
                                               var state = if(currentErrorCount &lt; {{{failureThreshold}}}) "CLOSED" 
-                                                          else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + ("PT$(vars.circuit.retryPeriod default 0)S" as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN"
+                                                          else if ( (currentErrorCount &gt;= {{{failureThreshold}}}) and ((vars.circuit.timestamp) + ("PT$(vars.circuit.retryPeriod default 0){{{retryPeriodUnit}}}" as Period) &lt; now()) and vars.circuit.state == "OPEN") "HALF-OPEN"
                                                           else "OPEN"
                                               ---
                                               {
                                                 "failureThreshold": {{{failureThreshold}}},
                                                 "retryPeriod": {{{retryPeriod}}},
+                                                "retryPeriodUnit": "{{{retryPeriodUnit}}}",
                                                 "state": state,
                                                 "timestamp": now(),
                                                 "errorCount": currentErrorCount
@@ -136,7 +138,7 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                                                 ---
                                                 "circuitBreaker": (vars.circuit update "timestamp" with now())
                                                 ++ "error": "The circuit is still open, not propagating new requests until " 
-                                                ++ vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod)S" as Period)]</http-transform:body>
+                                                ++ vars.circuit.timestamp + ("PT$(vars.circuit.retryPeriod){{{retryPeriodUnit}}}" as Period)]</http-transform:body>
                     </http-transform:set-response>
                 </otherwise>
             </choice>


### PR DESCRIPTION
_This includes commits from previously submitted PRs._

**Features:**
- Added giveCircuitResponse which determines if the circuitBreaker field is added to response.
- Added retry-after header when circuit is open per RFC2616 Section 14.37.
- Made policy's body responses consistent; they were previously inconsistent and even threw away the API's response in Check Status Code scenario.  This feature is documented in readme.
- Added retryAfter and errorStatusCode fields to circuitBreaker to replace the error field.
- Added empty HTTP body response (not null or {}) if nothing provided for cb trigger scenario.
- Updated README with new features.
- Moved most funcionality to subflows for reuse, better management, and visibility in Studio.
- Added additional debug loggers.
- Updated minimum version to 4.3 because using 'update' dataweave function.
- Updated **groupId** to ORG-ID in pom.xml.  This causes build error if not updated, which is desired to prevent confusion.  When using the old value, which is a valid ID, build works and then the deployment errors with 403 when using a valid token.
- Updated yaml with new descriptions, spelling fixes, proper case (Hours) instead of caps (HOURS), and made httpCodesArray & exceptionsArray not require quotes in the entry field which was super annoying.
- Updated to latest dependency versions.

**Fixes:**
- pom.xml: excluded http connector from the policy jar, which reduces its size from over 5MB to under 1MB.
- README: fixed misspellings.
- circuit-breaker-mule-4.yaml: osTtl failed because min and max int values were not there.  Prevents policy saving when customizing OS.
- circuit-breaker-mule-4.yaml: osTtlUnit failed for ms because milliseconds was spelled incorrectly.
- template.xml: Check Status Code scenario throws away API's error response body and just sends back CB info.