### PR TITLE
Bump OS connector version to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <mule.maven.plugin.version>3.2.7</mule.maven.plugin.version>
         <exchange.url>https://maven.anypoint.mulesoft.com/api/v1/organizations/${project.groupId}/maven</exchange.url> <!-- Change this value according your ORG ID -->
-        <os.version>1.1.1</os.version>
+        <os.version>1.2.1</os.version>
         <http.policy.transform.version>1.0.0</http.policy.transform.version>
     </properties>
 


### PR DESCRIPTION
Fix #12 

Updated OS connector version to 1.2.1

Tests executed:

1. Apply policy using a persistent object store with 1 hour TTL

<img width="1229" alt="image" src="https://user-images.githubusercontent.com/50634447/189964586-08345440-0893-4565-8497-de8d7951f300.png">

2. Check correct application of the policy in a sample API:
<img width="1369" alt="image" src="https://user-images.githubusercontent.com/50634447/189966212-6172806b-c46e-4446-b338-b7c5ef5e6b0d.png">


3. Trip the circuit based on the predefined parameters in 1:
<img width="1435" alt="image" src="https://user-images.githubusercontent.com/50634447/189966281-7c5d00e4-642d-4099-91f0-2cb85e719266.png">


4. Force a new error while the circuit is OPEN (to check incoming request not being propagated):
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/50634447/189966399-2f1b5b28-1410-4e5b-9284-d2c822c5c0ee.png">


5. Wait until the retry period is met and the circuit is CLOSED:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/50634447/189966475-a4217311-0582-4f04-87af-b78fffa5924b.png">



