### PR TITLE
Add osName configuration

### DIFF
--- a/circuit-breaker-mule-4.yaml
+++ b/circuit-breaker-mule-4.yaml
@@ -66,6 +66,13 @@ configuration:
     allowMultiple: false
     dependsOnKey: evaluateHttpResponse
     dependsOnValue: true
+  - propertyName: osName
+    name: Object Store's unique name
+    description: |
+        The unique identifier for the Object Store. To be used when level Resource-Level Policy is defined. Example: "cbstore".
+    type: string
+    optional: false
+    defaultValue: "cbstore"
   - propertyName: overrideOsSettings
     name: Override Object Store settings?
     description: Select this option to override default OS settings.
@@ -87,7 +94,7 @@ configuration:
     optional: true
     sensitive: false
     allowMultiple: false
-    defaultValue: "1"
+    defaultValue: 1
     dependsOnKey: overrideOsSettings
     dependsOnValue: true  
   - propertyName: osTtlUnit

--- a/src/main/mule/template.xml
+++ b/src/main/mule/template.xml
@@ -14,15 +14,15 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
 
     <!-- Object Store configuration -->
     {{#if overrideOsSettings}}
-        <os:object-store name="cbstore" persistent="{{{osPersistent}}}" entryTtl="{{{osTtl}}}" entryTtlUnit="{{{osTtlUnit}}}" />
+        <os:object-store name="{{{osName}}}" persistent="{{{osPersistent}}}" entryTtl="{{{osTtl}}}" entryTtlUnit="{{{osTtlUnit}}}" />
     {{else}}
-        <os:object-store name="cbstore" persistent="true" entryTtl="1" entryTtlUnit="HOURS" />
+        <os:object-store name="{{{osName}}}" persistent="true" entryTtl="1" entryTtlUnit="HOURS" />
     {{/if}}
     <http-policy:proxy name="{{{policyId}}}-custom-policy">
         <http-policy:source>
             <try>
                 <!-- Checking Cache for OPEN| HALF-OPEN stored value -->
-                <os:retrieve key="${apiId}" target="circuit"  objectStore="cbstore" />
+                <os:retrieve key="${apiId}" target="circuit"  objectStore="{{{osName}}}" />
                 <error-handler>
                     <on-error-continue type="OS:KEY_NOT_FOUND" logException="false" >
                         <logger message="Circuit is CLOSED. Continue processing. Before execution" level="DEBUG" category="com.mule.policies.circuitbreaker" />
@@ -42,7 +42,7 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                             </when>
                             <otherwise>
                                 <logger message="http-policy:execute-next completed. Removing cached circuit" level="DEBUG" category="com.mule.policies.circuitbreaker"></logger>
-                                <os:remove key="${apiId}" objectStore="cbstore"  />
+                                <os:remove key="${apiId}" objectStore="{{{osName}}}"  />
                             </otherwise>
                         </choice>
                         {{#if evaluateHttpResponse}}
@@ -72,7 +72,7 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                                         "timestamp": now(),
                                         "errorCount": currentErrorCount
                                        }]' variableName="circuit" />
-                                    <os:store key="${apiId}" objectStore="cbstore">
+                                    <os:store key="${apiId}" objectStore="{{{osName}}}">
                                         <os:value>
                                             #[vars.circuit]
                                         </os:value>
@@ -117,7 +117,7 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                                                 "errorCount": currentErrorCount
                                                }]'
                                                           variableName="circuit" />
-                                            <os:store key="${apiId}" objectStore="cbstore">
+                                            <os:store key="${apiId}" objectStore="{{{osName}}}">
                                                 <os:value>
                                                     #[vars.circuit]
                                                 </os:value>


### PR DESCRIPTION
The issue was that applying the same circuit breaker policy multiple times on an API would force them to share the same Object Store. As a result, if one policy set the circuit to Open, all other instances of the policy would also switch to Open, leading to unintended behavior.

Ideally, circuit breaker policies applied to the same API should operate independently. This would allow policies to be applied at the "Method & Resource Level" rather than only at the "API level".

To address this, I introduced a new `osName` setting, enabling differentiation of the Object Store in the API Manager settings.

API Manager setup:
<img width="868" alt="api_manager-api_with_two_policies" src="https://github.com/user-attachments/assets/70cb6ef2-4040-4c96-a058-5cfc8f8dcea0" />

Policy 1 (POST resource):
![Policy_1-POST_resource](https://github.com/user-attachments/assets/8f2a9663-d9cf-485f-856f-426bbc17be64)

Policy 2 (GET resource):
![Policy_2-GET_resource](https://github.com/user-attachments/assets/3bb39d80-6261-4c68-938a-dfb6848d0ebd)
